### PR TITLE
Remove explicit vm creation

### DIFF
--- a/examples/sample.rb
+++ b/examples/sample.rb
@@ -20,10 +20,10 @@ class Kubevirt
 	    'fk6MDKZlQHRpM2ZPBOk_lOtO6BhbKiGmEaYLD6Ul6AouqPTssjrn57zU4YNN26fv'\
 	    'z4_7JaATqOjtt5Qk-LaPAenpYW44KDlUed6Dm_KvVsxD5fEBoBRu4RO8P2A5sy66'\
 	    'Y-Qp7YlRX5VNrJ7BLQen-Vz1vQ'
-    @conn = Fog::Compute.new(provider => 'kubevirt',
-                             kubevirt_host => '192.168.121.121',
-                             kubevirt_port => '8443',
-                             kubevirt_token => token)
+    @conn = Fog::Compute.new(:provider => 'kubevirt',
+                             :kubevirt_hostname => '192.168.121.121',
+                             :kubevirt_port     => '8443',
+                             :kubevirt_token    => token)
   end
 
   #

--- a/lib/fog/compute/kubevirt.rb
+++ b/lib/fog/compute/kubevirt.rb
@@ -2,7 +2,7 @@ module Fog
   module Compute
     class Kubevirt < Fog::Service
       requires   :kubevirt_token
-      recognizes :kubevirt_host, :kubevirt_port
+      recognizes :kubevirt_hostname, :kubevirt_port
 
       model_path 'fog/compute/kubevirt/models'
       model      :livevm
@@ -65,7 +65,7 @@ module Fog
           require 'kubeclient'
 
           @kubevirt_token = options[:kubevirt_token]
-          @host  = options[:kubevirt_host]
+          @host  = options[:kubevirt_hostname]
           @port  = options[:kubevirt_port]
 
           @namespace = options[:kubevirt_namespace] || 'default'

--- a/lib/fog/compute/kubevirt/models/offlinevm.rb
+++ b/lib/fog/compute/kubevirt/models/offlinevm.rb
@@ -23,36 +23,6 @@ module Fog
             }
           )
           service.update_offline_vm(offline_vm)
-
-          # TODO: We need to create the live virtual machine explicitly because KubeVirt still doesn't have a controller
-          # that starts automatically the virtual machines when the `running` attribute is changed to `true`. This should be
-          # removed when that controller is added.
-          live_vm = {
-            :metadata => {
-              :namespace       => namespace,
-              :name            => name,
-              :ownerReferences => [{
-                :apiVersion => offline_vm[:apiVersion],
-                :kind       => offline_vm[:kind],
-                :name       => offline_vm[:metadata][:name],
-                :uid        => uid
-              }]
-            },
-            :spec     => offline_vm[:spec][:template][:spec]
-          }
-
-          # make sure to copy vm presets
-          unless offline_vm[:metadata][:selector].nil?
-            live_vm = live_vm.deep_merge(
-              :metadata => {
-                :namespace => {
-                  :selector => offline_vm[:metadata][:selector]
-                }
-              }
-            )
-          end
-
-          service.create_vm(live_vm)
         end
 
         def stop(options = {})

--- a/lib/fog/kubevirt/version.rb
+++ b/lib/fog/kubevirt/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Kubevirt
-    VERSION = '0.1'
+    VERSION = '0.1.0'
   end
 end


### PR DESCRIPTION
Since kubevirt v0.4.0 there is no longer a need to create the live vm entity explicitly.
