### PR TITLE
Use vm status provided by kubevirt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
+### 0.1.2 / 2018-05-25
 
+* Collect vm status from kubevirt
+* Fix resource_version naming
 
 ### 0.1.1 / 2018-05-22
 

--- a/lib/fog/compute/kubevirt.rb
+++ b/lib/fog/compute/kubevirt.rb
@@ -41,13 +41,11 @@ module Fog
       module Shared
 
         class EntityCollection < DelegateClass(Array)
-          attr_reader :kind, :resource_version, :uid, :type
+          attr_reader :kind, :resource_version
 
-          def initialize(kind, resource_version, uid, type, entities)
+          def initialize(kind, resource_version, entities)
             @kind = kind
             @resource_version = resource_version
-            @uid = uid
-            @type = type
             super(entities)
           end
         end

--- a/lib/fog/compute/kubevirt/models/livevm.rb
+++ b/lib/fog/compute/kubevirt/models/livevm.rb
@@ -15,6 +15,7 @@ module Fog
         attribute :volumes,          :aliases => 'spec_volumes'
         attribute :ip_address,       :aliases => 'status_interfaces_ip'
         attribute :node_name,        :aliases => 'status_node_name'
+        attribute :status,           :aliases => 'status_phase' 
 
         def self.parse(object)
           metadata = object[:metadata]
@@ -34,7 +35,8 @@ module Fog
             :disks            => domain[:devices][:disks],
             :volumes          => spec[:volumes],
             :ip_address       => status.dig(:interfaces, 0, :ipAddress),
-            :node_name        => status[:nodeName]
+            :node_name        => status[:nodeName],
+            :status           => status[:phase]
           }
         end
       end

--- a/lib/fog/compute/kubevirt/models/livevms.rb
+++ b/lib/fog/compute/kubevirt/models/livevms.rb
@@ -5,14 +5,14 @@ module Fog
   module Compute
     class Kubevirt
       class Livevms < Fog::Collection
-        attr_reader :kind, :resourceVersion
+        attr_reader :kind, :resource_version
 
         model Fog::Compute::Kubevirt::Livevm
 
         def all(filters = {})
           vms = service.list_livevms(filters)
           kind = vms.kind
-          resourceVersion = vms.resourceVersion
+          resource_version = vms.resource_version
           load vms
         end
 

--- a/lib/fog/compute/kubevirt/models/nodes.rb
+++ b/lib/fog/compute/kubevirt/models/nodes.rb
@@ -5,14 +5,14 @@ module Fog
   module Compute
     class Kubevirt
       class Nodes < Fog::Collection
-        attr_reader :kind, :resourceVersion
+        attr_reader :kind, :resource_version
 
         model Fog::Compute::Kubevirt::Node
 
         def all(filters = {})
           nodes = service.list_nodes(filters)
           kind = nodes.kind
-          resourceVersion = nodes.resourceVersion
+          resource_version = nodes.resource_version
           load nodes
         end
 

--- a/lib/fog/compute/kubevirt/models/offlinevms.rb
+++ b/lib/fog/compute/kubevirt/models/offlinevms.rb
@@ -5,14 +5,14 @@ module Fog
   module Compute
     class Kubevirt
       class Offlinevms < Fog::Collection
-        attr_reader :kind, :resourceVersion
+        attr_reader :kind, :resource_version
 
         model Fog::Compute::Kubevirt::Offlinevm
 
         def all(filters = {})
           ovms = service.list_offlinevms(filters)
           kind = ovms.kind
-          resourceVersion = ovms.resourceVersion
+          resource_version = ovms.resource_version
           load ovms
         end
 

--- a/lib/fog/compute/kubevirt/models/templates.rb
+++ b/lib/fog/compute/kubevirt/models/templates.rb
@@ -5,14 +5,14 @@ module Fog
   module Compute
     class Kubevirt
       class Templates < Fog::Collection
-        attr_reader :kind, :resourceVersion
+        attr_reader :kind, :resource_version
 
         model Fog::Compute::Kubevirt::Template
 
         def all(filters = {})
           temps = service.list_templates(filters)
           kind = temps.kind
-          resourceVersion = temps.resourceVersion
+          resource_version = temps.resource_version
           load temps
         end
 

--- a/lib/fog/compute/kubevirt/requests/list_livevms.rb
+++ b/lib/fog/compute/kubevirt/requests/list_livevms.rb
@@ -7,7 +7,7 @@ module Fog
           entities = vms.map do |kubevirt_obj|
             Livevm.parse object_to_hash(kubevirt_obj)
           end
-          EntityCollection.new(vms.kind, vms.resourceVersion, vms.metadata.uid, vms.metadata.type, entities)
+          EntityCollection.new(vms.kind, vms.resourceVersion, entities)
         end
       end
 

--- a/lib/fog/compute/kubevirt/requests/list_nodes.rb
+++ b/lib/fog/compute/kubevirt/requests/list_nodes.rb
@@ -5,7 +5,7 @@ module Fog
         def list_nodes(_filters = {})
           nodes = kube_client.get_nodes
           entities = nodes.map { |kubevirt_obj| Node.parse object_to_hash(kubevirt_obj) }
-          EntityCollection.new(nodes.kind, nodes.resourceVersion, vms.metadata.uid, vms.metadata.type, entities)
+          EntityCollection.new(nodes.kind, nodes.resourceVersion, entities)
         end
       end
 

--- a/lib/fog/compute/kubevirt/requests/list_offlinevms.rb
+++ b/lib/fog/compute/kubevirt/requests/list_offlinevms.rb
@@ -9,7 +9,7 @@ module Fog
           entities = ovms.map do |kubevirt_obj|
             Offlinevm.parse object_to_hash(kubevirt_obj)
           end
-          EntityCollection.new(ovms.kind, ovms.resourceVersion, ovms.metadata.uid, ovms.metadata.type, entities)
+          EntityCollection.new(ovms.kind, ovms.resourceVersion, entities)
         end
       end
 

--- a/lib/fog/compute/kubevirt/requests/list_templates.rb
+++ b/lib/fog/compute/kubevirt/requests/list_templates.rb
@@ -9,7 +9,7 @@ module Fog
           entities = temps.map do |kubevirt_obj|
             Template.parse object_to_hash(kubevirt_obj)
           end
-          EntityCollection.new(temps.kind, temps.resourceVersion, temps.metadata.uid, temps.metadata.type, entities)
+          EntityCollection.new(temps.kind, temps.resourceVersion, entities)
         end
       end
 

--- a/lib/fog/kubevirt/version.rb
+++ b/lib/fog/kubevirt/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Kubevirt
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end


### PR DESCRIPTION
We assumed about vm status based on part of the flow we were in.
This PR uses vm status as collected from kubevirt.