### PR TITLE
Fix expected vm instance type in notice

### DIFF
--- a/lib/fog/compute/kubevirt.rb
+++ b/lib/fog/compute/kubevirt.rb
@@ -219,7 +219,7 @@ module Fog
         #
         def watch_vminstances(opts = {})
           mapper = Proc.new do |notice|
-            vminstance = OpenStruct.new(Vminstance.parse(notice.object)) if notice.object.kind == 'VirtualMachine'
+            vminstance = OpenStruct.new(Vminstance.parse(notice.object)) if notice.object.kind == 'VirtualMachineInstance'
             vminstance ||= OpenStruct.new
 
             populate_notice_attributes(vminstance, notice)


### PR DESCRIPTION
Without setting the proper expected kind (VirtualMachineInstance), no VM Instance notices were processed.
Updating to the expected kind will fix that.