### PR TITLE
Support openshfit templates parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.1.6 / 2018-07-16
+
+* Support openshift parameters processing ${{PARAM_NAME}} in templates.
+
 ### 0.1.4 / 2018-06-25
 
 * Save resource_version and kind for entitiy collections

--- a/lib/fog/compute/kubevirt/models/template.rb
+++ b/lib/fog/compute/kubevirt/models/template.rb
@@ -184,9 +184,14 @@ module Fog
           result = object
           params.each_key do |name|
             token = "${#{name.upcase}}"
-            next unless object.include?(token)
+            os_token = "${{#{name.upcase}}}"
+            next unless (object.include?(token) || object.include?(os_token))
             result = if params[name].kind_of?(String)
-                       object.sub!(token, params[name])
+                       if object.include?(os_token)
+                         object.sub!(os_token, params[name])
+                       else
+                         object.sub!(token, params[name])
+                       end
                      else
                        params[name]
                      end

--- a/lib/fog/kubevirt/version.rb
+++ b/lib/fog/kubevirt/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Kubevirt
-    VERSION = '0.1.5'
+    VERSION = '0.1.6'
   end
 end


### PR DESCRIPTION
The PR adds support for both types of parameters: ${PARAM} and ${{PARAM}} by replacing both with value from the parameters section if such parameter exists.

