### PR TITLE
Loosen fog-core dependency

### DIFF
--- a/fog-kubevirt.gemspec
+++ b/fog-kubevirt.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"
 
-  spec.add_dependency("fog-core", "~> 2.1.2")
+  spec.add_dependency("fog-core", "~> 2.1")
   spec.add_dependency("kubeclient", "~> 2.5.2")
 end


### PR DESCRIPTION
Allow `~>` to follow a good practice by constraining on major and minor versions and loosen up on the bug version.
 
It also allows to use fog-core version 2.1.0 which used by other Fog projects before switching to coming release which will carry namespace changes which are going to be part of a new Major version release.
