### PR TITLE
vm: add status property

### DIFF
--- a/lib/fog/compute/kubevirt.rb
+++ b/lib/fog/compute/kubevirt.rb
@@ -126,6 +126,7 @@ module Fog
         #
         CORE_GROUP = ''.freeze
         CORE_VERSION = 'v1'.freeze
+        KUBEVIRT_VERSION_LABEL = KUBEVIRT_GROUP + '/' + KUBEVIRT_VERSION
 
         #
         # The API version and group of KubeVirt:
@@ -287,6 +288,10 @@ module Fog
             :port   => port,
           )
           url.to_s
+        end
+
+        def namespace
+          @namespace
         end
 
         private

--- a/lib/fog/compute/kubevirt/models/vm.rb
+++ b/lib/fog/compute/kubevirt/models/vm.rb
@@ -57,7 +57,7 @@ module Fog
             :memory           => domain[:resources][:requests][:memory],
             :disks            => domain[:devices][:disks],
             :volumes          => spec[:volumes],
-            :status           => object[:spec][:running].to_s == "true" ? "runnning" : "stopped"
+            :status           => object[:spec][:running].to_s == "true" ? "running" : "stopped"
           }
           vm[:owner_reference] = owner unless owner.nil?
           vm[:annotations] = annotations unless annotations.nil?

--- a/lib/fog/compute/kubevirt/models/vms.rb
+++ b/lib/fog/compute/kubevirt/models/vms.rb
@@ -5,6 +5,8 @@ module Fog
   module Compute
     class Kubevirt
       class Vms < Fog::Collection
+        include Shared
+
         attr_reader :kind, :resource_version
 
         model Fog::Compute::Kubevirt::Vm
@@ -23,6 +25,110 @@ module Fog
 
         def get(name)
           new service.get_vm(name)
+        end
+
+        # Creates a virtual machine using provided paramters:
+        # :vm_name [String] - name of a vm
+        # :cpus [String] - number of cpus
+        # :memory_size [String] - amount of memory
+        # :image [String] - name of a registry disk
+        # :pvc [String] - name of a persistent volume claim
+        #
+        # One of :image or :pvc needs to be provided.
+        #
+        # @param [Hash] attributes containing details about vm about to be
+        #   created.
+        def create(args = {})
+          vm_name = args.fetch(:vm_name)
+          cpus = args.fetch(:cpus, nil)
+          memory_size = args.fetch(:memory_size)
+          image = args.fetch(:image, nil)
+          pvc = args.fetch(:pvc, nil)
+
+          if image.nil? && pvc.nil?
+            raise ::Fog::Kubevirt::Errors::ValidationError
+          end
+          
+          volume = {}
+
+          if !image.nil?
+            volume = {
+              :name => vm_name,
+              :registryDisk => {
+                :image => image
+              }
+            }
+          else
+            volume = {
+              :name => vm_name,
+              :persistentVolumeClaim => {
+                :claimName => pvc
+              }
+            }
+          end
+
+          vm = {
+            :apiVersion => service.class::KUBEVIRT_VERSION_LABEL,
+            :kind => "VirtualMachine",
+            :metadata => {
+              :labels => {
+                :"kubevirt.io/vm" => vm_name,
+              },
+              :name => vm_name,
+              :namespace => service.namespace,
+            },
+            :spec => {
+              :running => false,
+              :template => {
+                :metadata => {
+                  :creationTimestamp => nil,
+                  :labels => {
+                    :"kubevirt.io/vm" => vm_name
+                  }
+                },
+                :spec => {
+                  :domain => {
+                    :devices => {
+                      :disks => [
+                        {:disk => {
+                           :bus => "virtio"
+                         },
+                         :name => vm_name,
+                         :volumeName => vm_name
+                        }
+                      ]
+                    },
+                    :machine => {
+                      :type => ""
+                    },
+                    :resources => {
+                      :requests => {
+                        :memory => "#{memory_size}M"
+                      }
+                    }
+                  },
+                  :terminationGracePeriodSeconds => 0,
+                  :volumes => [volume]
+                }
+              }
+            }
+          }
+
+          vm = deep_merge!(vm,
+            :spec => {
+              :template => {
+                :spec => {
+                  :domain => {
+                    :cpu => {
+                      :cores => cpus
+                    }
+                  }
+                }
+              }
+            }
+          ) unless cpus.nil?
+
+          service.create_vm(vm)
         end
       end
     end

--- a/lib/fog/kubevirt.rb
+++ b/lib/fog/kubevirt.rb
@@ -12,6 +12,7 @@ module Fog
       class ServiceError < Fog::Errors::Error; end
       class AlreadyExistsError < Fog::Errors::Error; end
       class ClientError < Fog::Errors::Error; end
+      class ValidationError < Fog::Errors::Error; end
     end
 
     service(:compute, 'Compute')


### PR DESCRIPTION
We want to know whether vm is in running state. As well as we want to be
more tolerant in terms of missing attribute during parsing process.

We add ability to create a vm without having a template.