### PR TITLE
Bump version to 1.x.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 1.0.1 / 2018-10-09
+
+* fog-core bumped to 2.1.1
+* Namespace change to Fog::Kubevirt per fog-core 2
+* Added VM status property
+* Allow to create VM without a template
+
 ### 0.1.6 / 2018-07-16
 
 * Support openshift parameters processing ${{PARAM_NAME}} in templates.

--- a/lib/fog/kubevirt/version.rb
+++ b/lib/fog/kubevirt/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Kubevirt
-    VERSION = '0.1.6'
+    VERSION = '1.0.1'
   end
 end


### PR DESCRIPTION
Since fog-core was promoted to 2.x, master is bumped as well.
This is designed to allow a clear separation between core-1.45
branch which is based on fog-core-1.45.0.