### PR TITLE
Allow local Gemfile.dev.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ tmp
 mkmf.log
 gemfiles/*.lock
 spec/debug
+Gemfile.dev.rb
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+dev_gemfile = File.expand_path("Gemfile.dev.rb", __dir__)
+eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
 
 gemspec


### PR DESCRIPTION
In order to add local dependencies (i.e. pry, byebug, pry-byebug...) - Gemfile is extended to support the options of loading local file.

Based on https://github.com/ManageIQ/manageiq-ui-classic/blob/master/Gemfile#L14