### PR TITLE
vm: cloud-init support

### DIFF
--- a/lib/fog/kubevirt/compute/models/vms.rb
+++ b/lib/fog/kubevirt/compute/models/vms.rb
@@ -34,6 +34,7 @@ module Fog
         # :memory_size [String] - amount of memory
         # :image [String] - name of a registry disk
         # :pvc [String] - name of a persistent volume claim
+        # :cloudinit [Hash] - number of items needed to configure cloud-init
         #
         # One of :image or :pvc needs to be provided.
         #
@@ -45,27 +46,22 @@ module Fog
           memory_size = args.fetch(:memory_size)
           image = args.fetch(:image, nil)
           pvc = args.fetch(:pvc, nil)
+          init = args.fetch(:cloudinit, {})
 
           if image.nil? && pvc.nil?
             raise ::Fog::Kubevirt::Errors::ValidationError
           end
           
-          volume = {}
+          volumes = []
 
           if !image.nil?
-            volume = {
-              :name => vm_name,
-              :registryDisk => {
-                :image => image
-              }
-            }
+            volumes.push(:name => vm_name, :registryDisk => {:image => image})
           else
-            volume = {
-              :name => vm_name,
-              :persistentVolumeClaim => {
-                :claimName => pvc
-              }
-            }
+            volumes.push(:name => vm_name, :persistentVolumeClaim => {:claimName => pvc})
+          end
+
+          unless init.empty?
+            volumes.push(:cloudInitNoCloud => init, :name => "cloudinitvolume")
           end
 
           vm = {
@@ -109,7 +105,7 @@ module Fog
                     }
                   },
                   :terminationGracePeriodSeconds => 0,
-                  :volumes => [volume]
+                  :volumes => volumes
                 }
               }
             }
@@ -128,6 +124,14 @@ module Fog
               }
             }
           ) unless cpus.nil?
+
+          vm[:spec][:template][:spec][:domain][:devices][:disks].push(
+            :disk => {
+              :bus => "virtio"
+            },
+            :name => "cloudinitdisk",
+            :volumeName => "cloudinitvolume"
+          ) unless init.empty?
 
           service.create_vm(vm)
         end


### PR DESCRIPTION
We need the ability to configure username and/or password when
we create a vm. This PR provides ability to pass cloud-init information.