### PR TITLE
gemspec: use latest kubeclient

### DIFF
--- a/fog-kubevirt.gemspec
+++ b/fog-kubevirt.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock'
 
   spec.add_dependency("fog-core", "~> 1.45")
-  spec.add_dependency("kubeclient", "~> 2.5.2")
+  spec.add_dependency("kubeclient", "~> 4.0.0")
 end


### PR DESCRIPTION
We need to update kubeclinet to the latest version.