### PR TITLE
Volume name should respect restrictions

### DIFF
--- a/lib/fog/compute/kubevirt/models/vms.rb
+++ b/lib/fog/compute/kubevirt/models/vms.rb
@@ -50,13 +50,13 @@ module Fog
           if image.nil? && pvc.nil?
             raise ::Fog::Kubevirt::Errors::ValidationError
           end
-          
-          volumes = []
 
+          volumes = []
+          volume_name = vm_name.gsub(/[._]+/,'-') + "-disk-01"
           if !image.nil?
-            volumes.push(:name => vm_name, :registryDisk => {:image => image})
+            volumes.push(:name => volume_name, :registryDisk => {:image => image})
           else
-            volumes.push(:name => vm_name, :persistentVolumeClaim => {:claimName => pvc})
+            volumes.push(:name => volume_name, :persistentVolumeClaim => {:claimName => pvc})
           end
 
           unless init.empty?
@@ -90,7 +90,7 @@ module Fog
                            :bus => "virtio"
                          },
                          :name => vm_name,
-                         :volumeName => vm_name
+                         :volumeName => volume_name
                         }
                       ]
                     },


### PR DESCRIPTION
In foreman, the VM name may contain also the domain name.
When setting this name as the volume name, running the VM fails
with the following error:

```
  Warning  FailedCreate  21s               virtualmachine-controller
  Error creating pod: Pod "virt-launcher-vmi-multus-lqcwz" is invalid:
  spec.containers[0].name: Invalid value: "volumevmi-multus.example.com":
  a DNS-1123 label must consist of lower case alphanumeric characters or '-',
  and must start and end with an alphanumeric character (e.g. 'my-name',
  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```

Therefore the dots from FQDN VM name cannot be part of the volume name.
The patch assumes the name without the domain should be sufficient.

For VM named `stacy-bulgin.example.com` the created volume name is `stacy-bulgin-example-com-disk-01`