### PR TITLE
Bump kubeclient to 4.1.2

### DIFF
--- a/fog-kubevirt.gemspec
+++ b/fog-kubevirt.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock'
 
   spec.add_dependency("fog-core", "~> 1.45")
-  spec.add_dependency("kubeclient", "~> 4.1.0")
+  spec.add_dependency("kubeclient", "~> 4.1.2")
 end


### PR DESCRIPTION
kubeclient 4.1.2 supports resource method names that include dashes in
their name, i.e. network-attachment-definition.