### PR TITLE
Make VmVolume a Fog model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 0.2.0 / 2019-01-23
+
+* Detect kubevirt api version
+* Change registry to container disk
+* Support Persistent Volume Claims
+* Bump kubeclient to 4.1.2
+* Support Persistent Volumes
+* Volume name should respect restrictions
+
 ### 0.1.8 / 2018-12-3
 
 * Bump kubeclient version to 4.1

--- a/lib/fog/kubevirt/version.rb
+++ b/lib/fog/kubevirt/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Kubevirt
-    VERSION = '0.1.8'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
Foreman expects vm.volumes to return an array of Fog::Model.
For that purpose, VmVolume is changed to inherit from it.