### PR TITLE
vagrant: required fixes to enable plugin again

### DIFF
--- a/lib/fog/kubevirt/compute/compute.rb
+++ b/lib/fog/kubevirt/compute/compute.rb
@@ -386,7 +386,7 @@ module Fog
           client = check_client(key)
           return client if client
 
-          client = :Kubeclient::Client.new(
+          client = Kubeclient::Client.new(
             url + path,
             version,
             ssl_options: context.ssl_options,

--- a/lib/fog/kubevirt/compute/models/vm_base.rb
+++ b/lib/fog/kubevirt/compute/models/vm_base.rb
@@ -34,7 +34,7 @@ module Fog
             :labels           => metadata[:labels],
             :disks            => domain[:devices][:disks],
             :volumes          => spec[:volumes],
-            :state            => object[:spec][:running].to_s == "true" ? "running" : "stopped",
+            :status           => object[:spec][:running].to_s == "true" ? "running" : "stopped",
           }
           vm[:owner_reference] = owner unless owner.nil?
           vm[:annotations] = annotations unless annotations.nil?

--- a/lib/fog/kubevirt/compute/models/vms.rb
+++ b/lib/fog/kubevirt/compute/models/vms.rb
@@ -60,8 +60,8 @@ module Fog
           image = args.fetch(:image, nil)
           pvc = args.fetch(:pvc, nil)
           init = args.fetch(:cloudinit, {})
-          networks = args.fetch(:networks)
-          interfaces = args.fetch(:interfaces)
+          networks = args.fetch(:networks, nil)
+          interfaces = args.fetch(:interfaces, nil)
 
           if image.nil? && pvc.nil?
             raise ::Fog::Kubevirt::Errors::ValidationError


### PR DESCRIPTION
This PR contains:
- fixing vm status
- setting default values for network and interfaces.
  vagrant-kubevirt do not manage networking at this point in time
- removing unneeded colon from Kubeclient