### PR TITLE
differentiate status and state

### DIFF
--- a/lib/fog/kubevirt/compute/models/server.rb
+++ b/lib/fog/kubevirt/compute/models/server.rb
@@ -25,7 +25,7 @@ module Fog
 
         def self.parse(object)
           server = parse_object(object)
-          server[:status] = object[:phase]
+          server[:state] = object[:phase]
           server[:node_name] = object[:node_name]
           server[:ip_address] = object[:ip_address]
           server

--- a/lib/fog/kubevirt/compute/models/vms.rb
+++ b/lib/fog/kubevirt/compute/models/vms.rb
@@ -142,8 +142,7 @@ module Fog
             :disk => {
               :bus => "virtio"
             },
-            :name => "cloudinitdisk",
-            :volumeName => "cloudinitvolume"
+            :name => "cloudinitvolume",
           ) unless init.empty?
 
           vm = deep_merge!(vm,


### PR DESCRIPTION
We need to keep correct status or state with correct model. This PR fixes cloud-init.