### PR TITLE
Fix broken vm creation

### DIFF
--- a/lib/fog/compute/kubevirt/models/vms.rb
+++ b/lib/fog/compute/kubevirt/models/vms.rb
@@ -103,7 +103,7 @@ module Fog
                         {:disk => {
                            :bus => "virtio"
                          },
-                         :name => vm_name,
+                         :name => volume_name,
                         }
                       ]
                     },


### PR DESCRIPTION
Recent VM API changes removed the volumeName from the disk section.
Instead, matching a dist to its volume is done by the disk name.
Therefore, the same value should be used for as volume name under
the volumes section and also as the disk name.