### PR TITLE
Replace VmVolume with Volume as main collection

### DIFF
--- a/lib/fog/compute/kubevirt.rb
+++ b/lib/fog/compute/kubevirt.rb
@@ -31,6 +31,8 @@ module Fog
       collection :storageclasses
       model      :template
       collection :templates
+      model      :volume
+      collection :volumes
 
       request_path 'fog/compute/kubevirt/requests'
       request :create_networkattachmentdef
@@ -67,6 +69,7 @@ module Fog
       request :list_services
       request :list_storageclasses
       request :list_templates
+      request :list_volumes
       request :update_vm
 
       module Shared

--- a/lib/fog/compute/kubevirt/models/vm_base.rb
+++ b/lib/fog/compute/kubevirt/models/vm_base.rb
@@ -33,14 +33,15 @@ module Fog
           annotations = metadata[:annotations]
           cpu = domain[:cpu]
           mem = domain.dig(:resources, :requests, :memory)
+          disks = parse_disks(domain[:devices][:disks])
           vm = {
             :namespace        => metadata[:namespace],
             :name             => metadata[:name],
             :resource_version => metadata[:resourceVersion],
             :uid              => metadata[:uid],
             :labels           => metadata[:labels],
-            :disks            => parse_disks(domain[:devices][:disks]),
-            :volumes          => parse_volumes(spec[:volumes]),
+            :disks            => disks,
+            :volumes          => parse_volumes(spec[:volumes], disks),
             :interfaces       => parse_interfaces(domain[:devices][:interfaces]),
             :networks         => parse_networks(spec[:networks]),
             :status           => object[:spec][:running].to_s == "true" ? "running" : "stopped",

--- a/lib/fog/compute/kubevirt/models/vminstance.rb
+++ b/lib/fog/compute/kubevirt/models/vminstance.rb
@@ -28,6 +28,7 @@ module Fog
           status = object[:status]
           spec = object[:spec]
           domain = spec[:domain]
+          disks = parse_disks(domain[:devices][:disks])
           {
             :namespace        => metadata[:namespace],
             :name             => metadata[:name],
@@ -37,8 +38,8 @@ module Fog
             :owner_uid        => metadata.dig(:ownerReferences, 0, :uid),
             :cpu_cores        => domain.dig(:cpu, :cores),
             :memory           => domain[:resources][:requests][:memory],
-            :disks            => parse_disks(domain[:devices][:disks]),
-            :volumes          => parse_volumes(spec[:volumes]),
+            :disks            => disks,
+            :volumes          => parse_volumes(spec[:volumes], disks),
             :interfaces       => parse_interfaces(domain[:devices][:interfaces]),
             :networks         => parse_networks(spec[:networks]),
             :ip_address       => status.dig(:interfaces, 0, :ipAddress),

--- a/lib/fog/compute/kubevirt/models/vms.rb
+++ b/lib/fog/compute/kubevirt/models/vms.rb
@@ -27,6 +27,10 @@ module Fog
           new service.get_vm(name)
         end
 
+        def delete(name)
+          service.delete_vm(name, service.namespace)
+        end
+
         # Creates a virtual machine using provided paramters:
         # :vm_name [String] - name of a vm
         # :cpus [String] - number of cpus
@@ -50,7 +54,7 @@ module Fog
         #
         # @param [String] :image name of container disk.
         #
-        # @param [Array]/@param[String] :pvc or one or more pvcs.
+        # @param [Array] :volumes the volumes (Fog::Compute::Kubevirt::Volume) to be used by the VM
         #
         # @param [Hash] attributes containing details about vm about to be
         #   created.
@@ -58,30 +62,16 @@ module Fog
           vm_name = args.fetch(:vm_name)
           cpus = args.fetch(:cpus, nil)
           memory_size = args.fetch(:memory_size)
-          image = args.fetch(:image, nil)
-          pvcs = Array(args.fetch(:pvc, []))
           init = args.fetch(:cloudinit, {})
           networks = args.fetch(:networks, nil)
           interfaces = args.fetch(:interfaces, nil)
+          vm_volumes =  args.fetch(:volumes, nil)
 
-          if image.nil? && pvcs.empty?
+          if vm_volumes.nil? || vm_volumes.empty?
             raise ::Fog::Kubevirt::Errors::ValidationError
           end
 
-          volumes = []
-          disks = []
-          normalized_vm_name = vm_name.gsub(/[._]+/,'-')
-          if !image.nil?
-            volume_name = normalized_vm_name + "-disk-01"
-            volumes.push(:name => volume_name, :containerDisk => {:image => image})
-            disks.push(:disk => {:bus => "virtio"}, :name => volume_name)
-          else
-            pvcs.each_with_index { |pvc, inx|
-              volume_name = normalized_vm_name + "-disk-0" + inx.to_s
-              volumes.push(:name => volume_name, :persistentVolumeClaim => {:claimName => pvc})
-              disks.push(:disk => {:bus => "virtio"}, :name => volume_name)
-            }
-          end
+          volumes, disks = add_vm_storage(vm_name, vm_volumes)
 
           unless init.empty?
             volumes.push(:cloudInitNoCloud => init, :name => "cloudinitvolume")
@@ -170,8 +160,45 @@ module Fog
               }
             }
           ) unless interfaces.nil?
-
           service.create_vm(vm)
+        end
+
+        def add_vm_storage(vm_name, vm_volumes)
+          normalized_vm_name = vm_name.gsub(/[._]+/,'-')
+          volumes, disks = [], []
+          vm_volumes.each_with_index do |v, idx|
+            volume_name = v.name || normalized_vm_name + "-disk-0" + idx.to_s
+            disk = {
+              :name => volume_name,
+              :disk => {}
+            }
+            disk[:bootOrder] = v.boot_order if v.boot_order
+
+            if v.type == 'containerDisk'
+              # set image
+              if v.config.nil?
+                volumes.push(:name => volume_name, :containerDisk => {:image => v.info})
+              else
+                volumes.push(:name => volume_name, v.type.to_sym => v.config)
+              end
+              disk[:disk][:bus] = v.bus || "virtio"
+            elsif v.type == 'persistentVolumeClaim'
+              # set claim
+              if v.config.nil?
+                volumes.push(:name => volume_name, :persistentVolumeClaim => {:claimName => v.info})
+              else
+                volumes.push(:name => volume_name, v.type.to_sym => v.config)
+              end
+              disk[:disk][:bus] = v.bus || "virtio"
+            else
+              # convert type into symbol and pass :config as volume content
+              volumes.push(:name => volume_name, v.type.to_sym => v.config)
+              disk[:disk][:bus] = v.bus if v.bus
+            end
+            disks.push(disk)
+          end
+
+          return volumes, disks
         end
       end
     end

--- a/lib/fog/compute/kubevirt/models/volume.rb
+++ b/lib/fog/compute/kubevirt/models/volume.rb
@@ -27,14 +27,18 @@ module Fog
           attribute :pvc
 
           # Hash that holds volume type specific configurations, used for adding volume for a vm
+          # The set of config properties may change from type to type, see documentation for the supported
+          # keys of each volume type:
+          # https://kubevirt.io/user-guide/docs/latest/creating-virtual-machines/disks-and-volumes.html#volumes
           attribute :config
 
-          # Disk attachment properties:
+          # Disk attachment properties, relevant when volumes are fetched via the vm:
 
           # the order (integer) of the device during boot sequence
           attribute :boot_order
 
-          # detemines how the disk will be presented to the guest OS if available
+          # detemines how the disk will be presented to the guest OS if available, supported values are:
+          # virtio, sata or scsi. See https://kubevirt.io/api-reference/master/definitions.html#_v1_disktarget
           attribute :bus
 
           def persisted?

--- a/lib/fog/compute/kubevirt/models/volume.rb
+++ b/lib/fog/compute/kubevirt/models/volume.rb
@@ -1,0 +1,53 @@
+require 'fog/compute/kubevirt/models/pvc'
+
+module Fog
+  module Compute
+    class Kubevirt
+      # Volumes represents volumes exist on kubevirt for vms:
+      # If volume is attached to a VM by disk, it will contain the attachment properties
+      # Disk Attachment properties are: boot_order and bus (when avaiable).
+      # If the volume isn't attached to any VM, it will contain name, type and info.
+      # When the volume type is persistentVolumeClaim, it will contain also the claim entity
+      # In order to create a new volume, user have to create a Claim when wishes to use PVC
+      # by using the pvcs collection.
+      class Volume < Fog::Model
+          identity :name
+
+          # values: containerDisk, persistentVolumeClaim, emptyDisk,
+          #         ephemeral, cloudInitNoCloud, hostDisk, secret,
+          #         dataVolume, serviceAccount, configMap
+          attribute :type
+
+          # specific piece of information per volume type
+          # for containerDisk - contains the image
+          # for persistentVolumeClaim - contains the claim name
+          attribute :info
+
+          # holds the pvc entity if its type is persistentVolumeClaim
+          attribute :pvc
+
+          # Hash that holds volume type specific configurations, used for adding volume for a vm
+          attribute :config
+
+          # Disk attachment properties:
+
+          # the order (integer) of the device during boot sequence
+          attribute :boot_order
+
+          # detemines how the disk will be presented to the guest OS if available
+          attribute :bus
+
+          def persisted?
+            !name.nil?
+          end
+
+        def self.parse(object, disk)
+          byebug
+          volume = parse_object(object)
+          volume[:boot_order] = object[:bootOrder]
+          volume
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/kubevirt/models/volumes.rb
+++ b/lib/fog/compute/kubevirt/models/volumes.rb
@@ -1,0 +1,18 @@
+require 'fog/core/collection'
+require 'fog/compute/kubevirt/models/volume'
+
+module Fog
+  module Compute
+    class Kubevirt
+      class Volumes < Fog::Collection
+        model Fog::Compute::Kubevirt::Volume
+
+        attr_accessor :vm
+
+        def all(vm_name = nil)
+          service.list_volumes(vm_name)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/kubevirt/requests/delete_vm.rb
+++ b/lib/fog/compute/kubevirt/requests/delete_vm.rb
@@ -8,7 +8,7 @@ module Fog
       end
 
       class Mock
-        def delete_vm(name)
+        def delete_vm(name, namespace)
         end
       end
     end

--- a/lib/fog/compute/kubevirt/requests/delete_vminstance.rb
+++ b/lib/fog/compute/kubevirt/requests/delete_vminstance.rb
@@ -2,13 +2,13 @@ module Fog
   module Compute
     class Kubevirt
       class Real
-        def delete_vminstance(name, namespace)
-          kubevirt_client.delete_virtual_machine_instance(name, namespace)
+        def delete_vminstance(name)
+          kubevirt_client.delete_virtual_machine_instance(name, @namespace)
         end
       end
 
       class Mock
-        def delete_virtual_machine_instance(name, namespace = nil)
+        def delete_virtual_machine_instance(name)
         end
       end
     end

--- a/lib/fog/compute/kubevirt/requests/list_volumes.rb
+++ b/lib/fog/compute/kubevirt/requests/list_volumes.rb
@@ -1,0 +1,30 @@
+require 'recursive_open_struct'
+
+module Fog
+  module Compute
+    class Kubevirt
+      class Real
+        def list_volumes(vm_name = nil)
+          if vm_name.nil?
+            entities = pvcs.all.map do |pvc|
+              volume = Volume.new
+              volume.name = pvc.name
+              volume.type = 'persistentVolumeClaim'
+              volume.pvc = pvc
+              volume
+            end
+            EntityCollection.new('Volume', pvcs.resource_version, entities)
+          else
+            vm = vms.get(vm_name)
+            EntityCollection.new('Volume', vm.resource_version, vm.volumes)
+          end
+        end
+      end
+
+      class Mock
+        def list_volumes(_filters = {})
+        end
+      end
+    end
+  end
+end

--- a/spec/create_vm_spec.rb
+++ b/spec/create_vm_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require_relative './shared_context'
 
 require 'fog/kubevirt'
+require 'fog/compute/kubevirt/models/volume'
 
 describe Fog::Compute do
   before :all do
@@ -18,10 +19,51 @@ describe Fog::Compute do
         vm_name = 'test'
         cpus = 1
         memory_size = 64
-        pvcs = ['mypvc1', 'mypvc2']
-        @service.vms.create(vm_name: vm_name, cpus: cpus, memory_size: memory_size, pvc: pvcs)
+
+        # PVCs should already be created
+        volume1 = Fog::Compute::Kubevirt::Volume.new
+        volume1.type = 'persistentVolumeClaim'
+        volume1.name = 'test-disk-01'
+        volume1.boot_order = 1
+        volume1.bus = 'virtio'
+        volume1.info = 'mypvc1'
+
+        volume2 = Fog::Compute::Kubevirt::Volume.new
+        volume2.type = 'persistentVolumeClaim'
+        volume2.name = 'test-disk-02'
+        volume2.boot_order = 2
+        volume2.bus = 'virtio'
+        volume2.info = 'mypvc2'
+
+        volume3 = Fog::Compute::Kubevirt::Volume.new
+        volume3.type = 'hostDisk'
+        volume3.name = 'test-disk-03'
+        volume3.boot_order = 3
+        volume3.config = {
+          :capacity => '1Gi',
+          :path     => '/mnt/data/disk.img',
+          :type     => 'DiskOrCreate'
+        }
+
+        @service.vms.create(vm_name: vm_name, cpus: cpus, memory_size: memory_size, volumes: [volume1, volume2, volume3])
 
         vm = @service.vms.get(vm_name)
+
+        # test vm volumes
+        volumes = @service.volumes.all vm_name
+        assert_equal(volumes.count, 3)
+
+        # verify first claim values
+        volume = volumes.select { |v| v.name == 'test-disk-01' }.first
+        refute_nil(volume)
+        assert_equal(volume.name, 'test-disk-01')
+        assert_equal(volume.type, 'persistentVolumeClaim')
+
+        # verify third claim values
+        volume = volumes.select { |v| v.name == 'test-disk-03' }.first
+        refute_nil(volume)
+        assert_equal(volume.name, 'test-disk-03')
+        assert_equal(volume.type, 'hostDisk')
       ensure
         @service.vms.delete(vm_name) if vm
       end
@@ -34,13 +76,26 @@ describe Fog::Compute do
         vm_name = 'test2'
         cpus = 1
         memory_size = 64
-        pvc = 'mypvc3'
-        @service.vms.create(vm_name: vm_name, cpus: cpus, memory_size: memory_size, pvc: pvc)
+
+        volume = Fog::Compute::Kubevirt::Volume.new
+        volume.type = 'persistentVolumeClaim'
+        volume.info = 'mypvc3'
+        @service.vms.create(vm_name: vm_name, cpus: cpus, memory_size: memory_size, volumes: [volume])
 
         vm = @service.vms.get(vm_name)
+
+        # test vm volumes
+        volumes = @service.volumes.all vm_name
+        assert_equal(volumes.count, 1)
+
+        # verify third claim values
+        volume = volumes.first
+        refute_nil(volume)
+        assert_equal(volume.name, 'test2-disk-00')
+        assert_equal(volume.type, 'persistentVolumeClaim')
       ensure
         @service.vms.delete(vm_name) if vm
-      end      
+      end
     end
   end
 end

--- a/spec/fixtures/kubevirt/pvc/pvcs_crud.yml
+++ b/spec/fixtures/kubevirt/pvc/pvcs_crud.yml
@@ -12,27 +12,25 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
   response:
     status:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-store
       Content-Type:
       - application/json
       Date:
-      - Tue, 22 Jan 2019 16:40:15 GMT
+      - Sun, 24 Mar 2019 20:18:17 GMT
       Content-Length:
-      - '162'
+      - '137'
     body:
       encoding: UTF-8
-      string: '{"kind":"APIVersions","versions":["v1"],"serverAddressByClientCIDRs":[{"clientCIDR":"0.0.0.0/0","serverAddress":"cnv-executor-vatsal-master1.example.com:8443"}]}
+      string: '{"kind":"APIVersions","versions":["v1"],"serverAddressByClientCIDRs":[{"clientCIDR":"0.0.0.0/0","serverAddress":"10.8.254.82:8443"}]}
 
 '
-    http_version: 
-  recorded_at: Tue, 22 Jan 2019 16:40:16 GMT
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:18:17 GMT
 - request:
     method: get
     uri: https://10.8.254.82:8443/api/v1
@@ -45,29 +43,27 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im15LWFjY291bnQtdG9rZW4ta3FsZDYiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibXktYWNjb3VudCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjJlYjVjZjU1LTFlNDUtMTFlOS1iYmZmLWZhMTYzZTM4OTEyYSIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpkZWZhdWx0Om15LWFjY291bnQifQ.aAigSXFZapxJdFy3FwgSNc77jZYFiSTlG7D_AnHzBT1ZP69xLmrqI_oXt73NDLpecNWezjIvsCU6sLf45tfPY2RQX_aEAOXKWjFs2SxWI7GeQ-sWRt0yd1sOB9R48ipTdpNpNs5pypnTRg6dYLvtePmBWyOSN2412F9XKeM79tuO9a_ynPDjkCwsWJXGj-gX9DwpHdGK-cup0YosJ-9OpvXoWOiUNeBi1KrvJxgQwgLytJk3PHFnJHv4mCNALvvo1cu89_ENwUQrvok267ACeq53YsivYn7B0QWuZoX3ca4Bx14kEdXbd-9BvIEBZzVovH2ZvPTYMmyXgnpO7c1eOw
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
   response:
     status:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-store
       Content-Type:
       - application/json
       Date:
-      - Tue, 22 Jan 2019 16:40:15 GMT
+      - Sun, 24 Mar 2019 20:18:17 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"kind":"APIResourceList","groupVersion":"v1","resources":[{"name":"bindings","singularName":"","namespaced":true,"kind":"Binding","verbs":["create"]},{"name":"componentstatuses","singularName":"","namespaced":false,"kind":"ComponentStatus","verbs":["get","list"],"shortNames":["cs"]},{"name":"configmaps","singularName":"","namespaced":true,"kind":"ConfigMap","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["cm"]},{"name":"endpoints","singularName":"","namespaced":true,"kind":"Endpoints","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ep"]},{"name":"events","singularName":"","namespaced":true,"kind":"Event","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ev"]},{"name":"limitranges","singularName":"","namespaced":true,"kind":"LimitRange","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["limits"]},{"name":"namespaces","singularName":"","namespaced":false,"kind":"Namespace","verbs":["create","delete","get","list","patch","update","watch"],"shortNames":["ns"]},{"name":"namespaces/finalize","singularName":"","namespaced":false,"kind":"Namespace","verbs":["update"]},{"name":"namespaces/status","singularName":"","namespaced":false,"kind":"Namespace","verbs":["get","patch","update"]},{"name":"nodes","singularName":"","namespaced":false,"kind":"Node","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["no"]},{"name":"nodes/proxy","singularName":"","namespaced":false,"kind":"Node","verbs":[]},{"name":"nodes/status","singularName":"","namespaced":false,"kind":"Node","verbs":["get","patch","update"]},{"name":"persistentvolumeclaims","singularName":"","namespaced":true,"kind":"PersistentVolumeClaim","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pvc"]},{"name":"persistentvolumeclaims/status","singularName":"","namespaced":true,"kind":"PersistentVolumeClaim","verbs":["get","patch","update"]},{"name":"persistentvolumes","singularName":"","namespaced":false,"kind":"PersistentVolume","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pv"]},{"name":"persistentvolumes/status","singularName":"","namespaced":false,"kind":"PersistentVolume","verbs":["get","patch","update"]},{"name":"pods","singularName":"","namespaced":true,"kind":"Pod","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["po"],"categories":["all"]},{"name":"pods/attach","singularName":"","namespaced":true,"kind":"Pod","verbs":[]},{"name":"pods/binding","singularName":"","namespaced":true,"kind":"Binding","verbs":["create"]},{"name":"pods/eviction","singularName":"","namespaced":true,"group":"policy","version":"v1beta1","kind":"Eviction","verbs":["create"]},{"name":"pods/exec","singularName":"","namespaced":true,"kind":"Pod","verbs":[]},{"name":"pods/log","singularName":"","namespaced":true,"kind":"Pod","verbs":["get"]},{"name":"pods/portforward","singularName":"","namespaced":true,"kind":"Pod","verbs":[]},{"name":"pods/proxy","singularName":"","namespaced":true,"kind":"Pod","verbs":[]},{"name":"pods/status","singularName":"","namespaced":true,"kind":"Pod","verbs":["get","patch","update"]},{"name":"podtemplates","singularName":"","namespaced":true,"kind":"PodTemplate","verbs":["create","delete","deletecollection","get","list","patch","update","watch"]},{"name":"replicationcontrollers","singularName":"","namespaced":true,"kind":"ReplicationController","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["rc"],"categories":["all"]},{"name":"replicationcontrollers/scale","singularName":"","namespaced":true,"group":"autoscaling","version":"v1","kind":"Scale","verbs":["get","patch","update"]},{"name":"replicationcontrollers/status","singularName":"","namespaced":true,"kind":"ReplicationController","verbs":["get","patch","update"]},{"name":"resourcequotas","singularName":"","namespaced":true,"kind":"ResourceQuota","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["quota"]},{"name":"resourcequotas/status","singularName":"","namespaced":true,"kind":"ResourceQuota","verbs":["get","patch","update"]},{"name":"secrets","singularName":"","namespaced":true,"kind":"Secret","verbs":["create","delete","deletecollection","get","list","patch","update","watch"]},{"name":"securitycontextconstraints","singularName":"","namespaced":false,"kind":"SecurityContextConstraints","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["scc"]},{"name":"serviceaccounts","singularName":"","namespaced":true,"kind":"ServiceAccount","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["sa"]},{"name":"services","singularName":"","namespaced":true,"kind":"Service","verbs":["create","delete","get","list","patch","update","watch"],"shortNames":["svc"],"categories":["all"]},{"name":"services/proxy","singularName":"","namespaced":true,"kind":"Service","verbs":[]},{"name":"services/status","singularName":"","namespaced":true,"kind":"Service","verbs":["get","patch","update"]}]}
+      string: '{"kind":"APIResourceList","groupVersion":"v1","resources":[{"name":"bindings","singularName":"","namespaced":true,"kind":"Binding","verbs":["create"]},{"name":"componentstatuses","singularName":"","namespaced":false,"kind":"ComponentStatus","verbs":["get","list"],"shortNames":["cs"]},{"name":"configmaps","singularName":"","namespaced":true,"kind":"ConfigMap","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["cm"]},{"name":"endpoints","singularName":"","namespaced":true,"kind":"Endpoints","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ep"]},{"name":"events","singularName":"","namespaced":true,"kind":"Event","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ev"]},{"name":"limitranges","singularName":"","namespaced":true,"kind":"LimitRange","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["limits"]},{"name":"namespaces","singularName":"","namespaced":false,"kind":"Namespace","verbs":["create","delete","get","list","patch","update","watch"],"shortNames":["ns"]},{"name":"namespaces/finalize","singularName":"","namespaced":false,"kind":"Namespace","verbs":["update"]},{"name":"namespaces/status","singularName":"","namespaced":false,"kind":"Namespace","verbs":["get","patch","update"]},{"name":"nodes","singularName":"","namespaced":false,"kind":"Node","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["no"]},{"name":"nodes/proxy","singularName":"","namespaced":false,"kind":"NodeProxyOptions","verbs":["create","delete","get","patch","update"]},{"name":"nodes/status","singularName":"","namespaced":false,"kind":"Node","verbs":["get","patch","update"]},{"name":"persistentvolumeclaims","singularName":"","namespaced":true,"kind":"PersistentVolumeClaim","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pvc"]},{"name":"persistentvolumeclaims/status","singularName":"","namespaced":true,"kind":"PersistentVolumeClaim","verbs":["get","patch","update"]},{"name":"persistentvolumes","singularName":"","namespaced":false,"kind":"PersistentVolume","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pv"]},{"name":"persistentvolumes/status","singularName":"","namespaced":false,"kind":"PersistentVolume","verbs":["get","patch","update"]},{"name":"pods","singularName":"","namespaced":true,"kind":"Pod","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["po"],"categories":["all"]},{"name":"pods/attach","singularName":"","namespaced":true,"kind":"PodAttachOptions","verbs":["create","get"]},{"name":"pods/binding","singularName":"","namespaced":true,"kind":"Binding","verbs":["create"]},{"name":"pods/eviction","singularName":"","namespaced":true,"group":"policy","version":"v1beta1","kind":"Eviction","verbs":["create"]},{"name":"pods/exec","singularName":"","namespaced":true,"kind":"PodExecOptions","verbs":["create","get"]},{"name":"pods/log","singularName":"","namespaced":true,"kind":"Pod","verbs":["get"]},{"name":"pods/portforward","singularName":"","namespaced":true,"kind":"PodPortForwardOptions","verbs":["create","get"]},{"name":"pods/proxy","singularName":"","namespaced":true,"kind":"PodProxyOptions","verbs":["create","delete","get","patch","update"]},{"name":"pods/status","singularName":"","namespaced":true,"kind":"Pod","verbs":["get","patch","update"]},{"name":"podtemplates","singularName":"","namespaced":true,"kind":"PodTemplate","verbs":["create","delete","deletecollection","get","list","patch","update","watch"]},{"name":"replicationcontrollers","singularName":"","namespaced":true,"kind":"ReplicationController","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["rc"],"categories":["all"]},{"name":"replicationcontrollers/scale","singularName":"","namespaced":true,"group":"autoscaling","version":"v1","kind":"Scale","verbs":["get","patch","update"]},{"name":"replicationcontrollers/status","singularName":"","namespaced":true,"kind":"ReplicationController","verbs":["get","patch","update"]},{"name":"resourcequotas","singularName":"","namespaced":true,"kind":"ResourceQuota","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["quota"]},{"name":"resourcequotas/status","singularName":"","namespaced":true,"kind":"ResourceQuota","verbs":["get","patch","update"]},{"name":"secrets","singularName":"","namespaced":true,"kind":"Secret","verbs":["create","delete","deletecollection","get","list","patch","update","watch"]},{"name":"serviceaccounts","singularName":"","namespaced":true,"kind":"ServiceAccount","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["sa"]},{"name":"services","singularName":"","namespaced":true,"kind":"Service","verbs":["create","delete","get","list","patch","update","watch"],"shortNames":["svc"],"categories":["all"]},{"name":"services/proxy","singularName":"","namespaced":true,"kind":"ServiceProxyOptions","verbs":["create","delete","get","patch","update"]},{"name":"services/status","singularName":"","namespaced":true,"kind":"Service","verbs":["get","patch","update"]}]}
 
 '
-    http_version: 
-  recorded_at: Tue, 22 Jan 2019 16:40:16 GMT
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:18:17 GMT
 - request:
     method: post
     uri: https://10.8.254.82:8443/api/v1/namespaces/default/persistentvolumeclaims
@@ -80,11 +76,11 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im15LWFjY291bnQtdG9rZW4ta3FsZDYiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibXktYWNjb3VudCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjJlYjVjZjU1LTFlNDUtMTFlOS1iYmZmLWZhMTYzZTM4OTEyYSIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpkZWZhdWx0Om15LWFjY291bnQifQ.aAigSXFZapxJdFy3FwgSNc77jZYFiSTlG7D_AnHzBT1ZP69xLmrqI_oXt73NDLpecNWezjIvsCU6sLf45tfPY2RQX_aEAOXKWjFs2SxWI7GeQ-sWRt0yd1sOB9R48ipTdpNpNs5pypnTRg6dYLvtePmBWyOSN2412F9XKeM79tuO9a_ynPDjkCwsWJXGj-gX9DwpHdGK-cup0YosJ-9OpvXoWOiUNeBi1KrvJxgQwgLytJk3PHFnJHv4mCNALvvo1cu89_ENwUQrvok267ACeq53YsivYn7B0QWuZoX3ca4Bx14kEdXbd-9BvIEBZzVovH2ZvPTYMmyXgnpO7c1eOw
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
       Content-Length:
       - '364'
   response:
@@ -92,21 +88,19 @@ http_interactions:
       code: 201
       message: Created
     headers:
-      Cache-Control:
-      - no-store
       Content-Type:
       - application/json
       Date:
-      - Tue, 22 Jan 2019 16:40:16 GMT
+      - Sun, 24 Mar 2019 20:18:17 GMT
       Content-Length:
-      - '600'
+      - '574'
     body:
       encoding: UTF-8
-      string: '{"kind":"PersistentVolumeClaim","apiVersion":"v1","metadata":{"name":"my-local-storage-pvc","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/my-local-storage-pvc","uid":"65c82fd5-1e64-11e9-bbff-fa163e38912a","resourceVersion":"56920","creationTimestamp":"2019-01-22T16:40:16Z","finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"selector":{},"resources":{"limits":{"storage":"3Gi"},"requests":{"storage":"2Gi"}},"volumeName":"my-local-storage","storageClassName":"manual","volumeMode":"Filesystem"},"status":{"phase":"Pending"}}
+      string: '{"kind":"PersistentVolumeClaim","apiVersion":"v1","metadata":{"name":"my-local-storage-pvc","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/my-local-storage-pvc","uid":"f616f5ab-4e71-11e9-8e8c-5254007d353d","resourceVersion":"3258448","creationTimestamp":"2019-03-24T20:18:17Z"},"spec":{"accessModes":["ReadWriteOnce"],"selector":{},"resources":{"limits":{"storage":"3Gi"},"requests":{"storage":"2Gi"}},"volumeName":"my-local-storage","storageClassName":"manual","volumeMode":"Filesystem","dataSource":null},"status":{"phase":"Pending"}}
 
 '
-    http_version: 
-  recorded_at: Tue, 22 Jan 2019 16:40:17 GMT
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:18:17 GMT
 - request:
     method: get
     uri: https://10.8.254.82:8443/api
@@ -119,27 +113,25 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
   response:
     status:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-store
       Content-Type:
       - application/json
       Date:
-      - Tue, 22 Jan 2019 16:40:16 GMT
+      - Sun, 24 Mar 2019 20:18:17 GMT
       Content-Length:
-      - '162'
+      - '137'
     body:
       encoding: UTF-8
-      string: '{"kind":"APIVersions","versions":["v1"],"serverAddressByClientCIDRs":[{"clientCIDR":"0.0.0.0/0","serverAddress":"cnv-executor-vatsal-master1.example.com:8443"}]}
+      string: '{"kind":"APIVersions","versions":["v1"],"serverAddressByClientCIDRs":[{"clientCIDR":"0.0.0.0/0","serverAddress":"10.8.254.82:8443"}]}
 
 '
-    http_version: 
-  recorded_at: Tue, 22 Jan 2019 16:40:17 GMT
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:18:17 GMT
 - request:
     method: get
     uri: https://10.8.254.82:8443/api/v1/namespaces/default/persistentvolumeclaims/my-local-storage-pvc
@@ -152,29 +144,27 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im15LWFjY291bnQtdG9rZW4ta3FsZDYiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibXktYWNjb3VudCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjJlYjVjZjU1LTFlNDUtMTFlOS1iYmZmLWZhMTYzZTM4OTEyYSIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpkZWZhdWx0Om15LWFjY291bnQifQ.aAigSXFZapxJdFy3FwgSNc77jZYFiSTlG7D_AnHzBT1ZP69xLmrqI_oXt73NDLpecNWezjIvsCU6sLf45tfPY2RQX_aEAOXKWjFs2SxWI7GeQ-sWRt0yd1sOB9R48ipTdpNpNs5pypnTRg6dYLvtePmBWyOSN2412F9XKeM79tuO9a_ynPDjkCwsWJXGj-gX9DwpHdGK-cup0YosJ-9OpvXoWOiUNeBi1KrvJxgQwgLytJk3PHFnJHv4mCNALvvo1cu89_ENwUQrvok267ACeq53YsivYn7B0QWuZoX3ca4Bx14kEdXbd-9BvIEBZzVovH2ZvPTYMmyXgnpO7c1eOw
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
   response:
     status:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-store
       Content-Type:
       - application/json
       Date:
-      - Tue, 22 Jan 2019 16:40:17 GMT
+      - Sun, 24 Mar 2019 20:18:17 GMT
       Content-Length:
-      - '600'
+      - '620'
     body:
       encoding: UTF-8
-      string: '{"kind":"PersistentVolumeClaim","apiVersion":"v1","metadata":{"name":"my-local-storage-pvc","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/my-local-storage-pvc","uid":"65c82fd5-1e64-11e9-bbff-fa163e38912a","resourceVersion":"56920","creationTimestamp":"2019-01-22T16:40:16Z","finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"selector":{},"resources":{"limits":{"storage":"3Gi"},"requests":{"storage":"2Gi"}},"volumeName":"my-local-storage","storageClassName":"manual","volumeMode":"Filesystem"},"status":{"phase":"Pending"}}
+      string: '{"kind":"PersistentVolumeClaim","apiVersion":"v1","metadata":{"name":"my-local-storage-pvc","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/my-local-storage-pvc","uid":"f616f5ab-4e71-11e9-8e8c-5254007d353d","resourceVersion":"3258449","creationTimestamp":"2019-03-24T20:18:17Z","finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"selector":{},"resources":{"limits":{"storage":"3Gi"},"requests":{"storage":"2Gi"}},"volumeName":"my-local-storage","storageClassName":"manual","volumeMode":"Filesystem","dataSource":null},"status":{"phase":"Pending"}}
 
 '
-    http_version: 
-  recorded_at: Tue, 22 Jan 2019 16:40:18 GMT
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:18:17 GMT
 - request:
     method: get
     uri: https://10.8.254.82:8443/api
@@ -187,27 +177,89 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
   response:
     status:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-store
       Content-Type:
       - application/json
       Date:
-      - Tue, 22 Jan 2019 16:40:17 GMT
+      - Sun, 24 Mar 2019 20:18:17 GMT
       Content-Length:
-      - '162'
+      - '137'
     body:
       encoding: UTF-8
-      string: '{"kind":"APIVersions","versions":["v1"],"serverAddressByClientCIDRs":[{"clientCIDR":"0.0.0.0/0","serverAddress":"cnv-executor-vatsal-master1.example.com:8443"}]}
+      string: '{"kind":"APIVersions","versions":["v1"],"serverAddressByClientCIDRs":[{"clientCIDR":"0.0.0.0/0","serverAddress":"10.8.254.82:8443"}]}
 
 '
-    http_version: 
-  recorded_at: Tue, 22 Jan 2019 16:40:18 GMT
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:18:17 GMT
+- request:
+    method: get
+    uri: https://10.8.254.82:8443/api/v1/namespaces/default/persistentvolumeclaims
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 24 Mar 2019 20:18:17 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"kind":"PersistentVolumeClaimList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/default/persistentvolumeclaims","resourceVersion":"3258451"},"items":[{"metadata":{"name":"example-local-claim","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/example-local-claim","uid":"9dff5ace-4aee-11e9-8999-5254007d353d","resourceVersion":"2657730","creationTimestamp":"2019-03-20T09:00:32Z","annotations":{"pv.kubernetes.io/bind-completed":"yes","pv.kubernetes.io/bound-by-controller":"yes"},"finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"5Gi"}},"volumeName":"example-local-pv","storageClassName":"local-storage","volumeMode":"Filesystem","dataSource":null},"status":{"phase":"Bound","accessModes":["ReadWriteOnce"],"capacity":{"storage":"10Gi"}}},{"metadata":{"name":"my-local-storage-pvc","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/my-local-storage-pvc","uid":"f616f5ab-4e71-11e9-8e8c-5254007d353d","resourceVersion":"3258449","creationTimestamp":"2019-03-24T20:18:17Z","finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"selector":{},"resources":{"limits":{"storage":"3Gi"},"requests":{"storage":"2Gi"}},"volumeName":"my-local-storage","storageClassName":"manual","volumeMode":"Filesystem","dataSource":null},"status":{"phase":"Pending"}},{"metadata":{"name":"task-pvc-1","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/task-pvc-1","uid":"dcae2a60-2271-11e9-94df-5254007d353d","resourceVersion":"24786","creationTimestamp":"2019-01-27T20:26:44Z","annotations":{"pv.kubernetes.io/bind-completed":"yes"},"finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"volumeName":"task-pv-volume1","storageClassName":"manual","volumeMode":"Filesystem","dataSource":null},"status":{"phase":"Bound","accessModes":["ReadWriteOnce"],"capacity":{"storage":"10Gi"}}},{"metadata":{"name":"task-pvc-2","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/task-pvc-2","uid":"de51baab-2271-11e9-94df-5254007d353d","resourceVersion":"24769","creationTimestamp":"2019-01-27T20:26:46Z","annotations":{"pv.kubernetes.io/bind-completed":"yes"},"finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"volumeName":"task-pv-volume2","storageClassName":"manual","volumeMode":"Filesystem","dataSource":null},"status":{"phase":"Bound","accessModes":["ReadWriteOnce"],"capacity":{"storage":"10Gi"}}},{"metadata":{"name":"task-pvc-3","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/task-pvc-3","uid":"dff6a5e1-2271-11e9-94df-5254007d353d","resourceVersion":"24784","creationTimestamp":"2019-01-27T20:26:49Z","annotations":{"pv.kubernetes.io/bind-completed":"yes"},"finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"3Gi"}},"volumeName":"task-pv-volume3","storageClassName":"manual","volumeMode":"Filesystem","dataSource":null},"status":{"phase":"Bound","accessModes":["ReadWriteOnce"],"capacity":{"storage":"10Gi"}}},{"metadata":{"name":"task-pvc-4","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/task-pvc-4","uid":"e1be5a89-2271-11e9-94df-5254007d353d","resourceVersion":"24824","creationTimestamp":"2019-01-27T20:26:52Z","annotations":{"pv.kubernetes.io/bind-completed":"yes"},"finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"4Gi"}},"volumeName":"task-pv-volume4","storageClassName":"manual","volumeMode":"Filesystem","dataSource":null},"status":{"phase":"Bound","accessModes":["ReadWriteOnce"],"capacity":{"storage":"10Gi"}}},{"metadata":{"name":"task-pvc-5","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/task-pvc-5","uid":"e34e0a43-2271-11e9-94df-5254007d353d","resourceVersion":"24826","creationTimestamp":"2019-01-27T20:26:55Z","annotations":{"pv.kubernetes.io/bind-completed":"yes"},"finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"5Gi"}},"volumeName":"task-pv-volume5","storageClassName":"manual","volumeMode":"Filesystem","dataSource":null},"status":{"phase":"Bound","accessModes":["ReadWriteOnce"],"capacity":{"storage":"10Gi"}}}]}
+
+'
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:18:17 GMT
+- request:
+    method: get
+    uri: https://10.8.254.82:8443/api
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 24 Mar 2019 20:18:17 GMT
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"APIVersions","versions":["v1"],"serverAddressByClientCIDRs":[{"clientCIDR":"0.0.0.0/0","serverAddress":"10.8.254.82:8443"}]}
+
+'
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:18:17 GMT
 - request:
     method: get
     uri: https://10.8.254.82:8443/api/v1/namespaces/default/persistentvolumeclaims/my-local-storage-pvc
@@ -220,29 +272,27 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im15LWFjY291bnQtdG9rZW4ta3FsZDYiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibXktYWNjb3VudCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjJlYjVjZjU1LTFlNDUtMTFlOS1iYmZmLWZhMTYzZTM4OTEyYSIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpkZWZhdWx0Om15LWFjY291bnQifQ.aAigSXFZapxJdFy3FwgSNc77jZYFiSTlG7D_AnHzBT1ZP69xLmrqI_oXt73NDLpecNWezjIvsCU6sLf45tfPY2RQX_aEAOXKWjFs2SxWI7GeQ-sWRt0yd1sOB9R48ipTdpNpNs5pypnTRg6dYLvtePmBWyOSN2412F9XKeM79tuO9a_ynPDjkCwsWJXGj-gX9DwpHdGK-cup0YosJ-9OpvXoWOiUNeBi1KrvJxgQwgLytJk3PHFnJHv4mCNALvvo1cu89_ENwUQrvok267ACeq53YsivYn7B0QWuZoX3ca4Bx14kEdXbd-9BvIEBZzVovH2ZvPTYMmyXgnpO7c1eOw
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
   response:
     status:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-store
       Content-Type:
       - application/json
       Date:
-      - Tue, 22 Jan 2019 16:40:18 GMT
+      - Sun, 24 Mar 2019 20:18:17 GMT
       Content-Length:
-      - '600'
+      - '620'
     body:
       encoding: UTF-8
-      string: '{"kind":"PersistentVolumeClaim","apiVersion":"v1","metadata":{"name":"my-local-storage-pvc","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/my-local-storage-pvc","uid":"65c82fd5-1e64-11e9-bbff-fa163e38912a","resourceVersion":"56920","creationTimestamp":"2019-01-22T16:40:16Z","finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"selector":{},"resources":{"limits":{"storage":"3Gi"},"requests":{"storage":"2Gi"}},"volumeName":"my-local-storage","storageClassName":"manual","volumeMode":"Filesystem"},"status":{"phase":"Pending"}}
+      string: '{"kind":"PersistentVolumeClaim","apiVersion":"v1","metadata":{"name":"my-local-storage-pvc","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/my-local-storage-pvc","uid":"f616f5ab-4e71-11e9-8e8c-5254007d353d","resourceVersion":"3258449","creationTimestamp":"2019-03-24T20:18:17Z","finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"selector":{},"resources":{"limits":{"storage":"3Gi"},"requests":{"storage":"2Gi"}},"volumeName":"my-local-storage","storageClassName":"manual","volumeMode":"Filesystem","dataSource":null},"status":{"phase":"Pending"}}
 
 '
-    http_version: 
-  recorded_at: Tue, 22 Jan 2019 16:40:19 GMT
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:18:17 GMT
 - request:
     method: get
     uri: https://10.8.254.82:8443/api
@@ -255,27 +305,25 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
   response:
     status:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-store
       Content-Type:
       - application/json
       Date:
-      - Tue, 22 Jan 2019 16:40:19 GMT
+      - Sun, 24 Mar 2019 20:18:17 GMT
       Content-Length:
-      - '162'
+      - '137'
     body:
       encoding: UTF-8
-      string: '{"kind":"APIVersions","versions":["v1"],"serverAddressByClientCIDRs":[{"clientCIDR":"0.0.0.0/0","serverAddress":"cnv-executor-vatsal-master1.example.com:8443"}]}
+      string: '{"kind":"APIVersions","versions":["v1"],"serverAddressByClientCIDRs":[{"clientCIDR":"0.0.0.0/0","serverAddress":"10.8.254.82:8443"}]}
 
 '
-    http_version: 
-  recorded_at: Tue, 22 Jan 2019 16:40:20 GMT
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:18:17 GMT
 - request:
     method: delete
     uri: https://10.8.254.82:8443/api/v1/namespaces/default/persistentvolumeclaims/my-local-storage-pvc
@@ -288,29 +336,27 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im15LWFjY291bnQtdG9rZW4ta3FsZDYiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoibXktYWNjb3VudCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjJlYjVjZjU1LTFlNDUtMTFlOS1iYmZmLWZhMTYzZTM4OTEyYSIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpkZWZhdWx0Om15LWFjY291bnQifQ.aAigSXFZapxJdFy3FwgSNc77jZYFiSTlG7D_AnHzBT1ZP69xLmrqI_oXt73NDLpecNWezjIvsCU6sLf45tfPY2RQX_aEAOXKWjFs2SxWI7GeQ-sWRt0yd1sOB9R48ipTdpNpNs5pypnTRg6dYLvtePmBWyOSN2412F9XKeM79tuO9a_ynPDjkCwsWJXGj-gX9DwpHdGK-cup0YosJ-9OpvXoWOiUNeBi1KrvJxgQwgLytJk3PHFnJHv4mCNALvvo1cu89_ENwUQrvok267ACeq53YsivYn7B0QWuZoX3ca4Bx14kEdXbd-9BvIEBZzVovH2ZvPTYMmyXgnpO7c1eOw
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
   response:
     status:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-store
       Content-Type:
       - application/json
       Date:
-      - Tue, 22 Jan 2019 16:40:19 GMT
+      - Sun, 24 Mar 2019 20:18:17 GMT
       Content-Length:
-      - '674'
+      - '694'
     body:
       encoding: UTF-8
-      string: '{"kind":"PersistentVolumeClaim","apiVersion":"v1","metadata":{"name":"my-local-storage-pvc","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/my-local-storage-pvc","uid":"65c82fd5-1e64-11e9-bbff-fa163e38912a","resourceVersion":"56935","creationTimestamp":"2019-01-22T16:40:16Z","deletionTimestamp":"2019-01-22T16:40:19Z","deletionGracePeriodSeconds":0,"finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"selector":{},"resources":{"limits":{"storage":"3Gi"},"requests":{"storage":"2Gi"}},"volumeName":"my-local-storage","storageClassName":"manual","volumeMode":"Filesystem"},"status":{"phase":"Pending"}}
+      string: '{"kind":"PersistentVolumeClaim","apiVersion":"v1","metadata":{"name":"my-local-storage-pvc","namespace":"default","selfLink":"/api/v1/namespaces/default/persistentvolumeclaims/my-local-storage-pvc","uid":"f616f5ab-4e71-11e9-8e8c-5254007d353d","resourceVersion":"3258452","creationTimestamp":"2019-03-24T20:18:17Z","deletionTimestamp":"2019-03-24T20:18:17Z","deletionGracePeriodSeconds":0,"finalizers":["kubernetes.io/pvc-protection"]},"spec":{"accessModes":["ReadWriteOnce"],"selector":{},"resources":{"limits":{"storage":"3Gi"},"requests":{"storage":"2Gi"}},"volumeName":"my-local-storage","storageClassName":"manual","volumeMode":"Filesystem","dataSource":null},"status":{"phase":"Pending"}}
 
 '
-    http_version: 
-  recorded_at: Tue, 22 Jan 2019 16:40:20 GMT
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:18:17 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/kubevirt/vm/vm_create_multi.yml
+++ b/spec/fixtures/kubevirt/vm/vm_create_multi.yml
@@ -2,139 +2,40 @@
 http_interactions:
 - request:
     method: get
-    uri: https://10.8.254.82:8443/apis/kubevirt.io
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
-      Content-Length:
-      - '274'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"},{"groupVersion":"kubevirt.io/v1alpha1","version":"v1alpha1"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
-
-'
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
-- request:
-    method: get
-    uri: https://10.8.254.82:8443/apis/kubevirt.io
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
-      Content-Length:
-      - '274'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"},{"groupVersion":"kubevirt.io/v1alpha1","version":"v1alpha1"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
-
-'
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
-- request:
-    method: get
-    uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJldmlydCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJrdWJldmlydC1wcml2aWxlZ2VkLXRva2VuLThwbDg5Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Imt1YmV2aXJ0LXByaXZpbGVnZWQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiJkY2I3NjMwMC0zZTZhLTExZTktODk4Ny1iY2UyMjM1M2E1MDUiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6a3ViZXZpcnQ6a3ViZXZpcnQtcHJpdmlsZWdlZCJ9.hFy9NZ1JD-YSXFnBiPDYBeCe1N8_GF3wvTyDCZ_JmMU-aFN-vo-KOkoRJ46Z9oRiexMLV4wsEGEQVdxK4Fi1DObmNni9s2pEwaC-Ae4hylY3rredliwqsHxHMsfOlTc2M0aJmnpLMCB-8H0Bk4RjT_CqIGZzFgWpVgMItd8WtrLADX5jQ9muGhJA8uMvlkPQ97RQ05ndjrJ7glRb497JqdaOrvu6CQoxei309JIVUcMzwzKXtvLwMMJGN5eJppULIywOrIHZHA-X_RPzfQcNIfpApNis4mEJNJZu717-HvmL0pHK8Xld93pvBXW-SeknwzpTRGRfE4_jWDQaQ4yBNg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
-      Content-Length:
-      - '1526'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"kubevirt.io/v1alpha3","resources":[{"name":"virtualmachineinstancemigrations","singularName":"virtualmachineinstancemigration","namespaced":true,"kind":"VirtualMachineInstanceMigration","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vmim","vmims"]},{"name":"virtualmachineinstancepresets","singularName":"virtualmachineinstancepreset","namespaced":true,"kind":"VirtualMachineInstancePreset","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vmipreset","vmipresets"]},{"name":"virtualmachineinstancereplicasets","singularName":"virtualmachineinstancereplicaset","namespaced":true,"kind":"VirtualMachineInstanceReplicaSet","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vmirs","vmirss"]},{"name":"virtualmachineinstancereplicasets/scale","singularName":"","namespaced":true,"group":"autoscaling","version":"v1","kind":"Scale","verbs":["get","patch","update"]},{"name":"virtualmachineinstances","singularName":"virtualmachineinstance","namespaced":true,"kind":"VirtualMachineInstance","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vmi","vmis"]},{"name":"virtualmachines","singularName":"virtualmachine","namespaced":true,"kind":"VirtualMachine","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vm","vms"]}]}
-
-'
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
-- request:
-    method: post
     uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines
     body:
-      encoding: UTF-8
-      string: '{"kind":"VirtualMachine","metadata":{"labels":{"kubevirt.io/vm":"test"},"name":"test","namespace":"default"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test"}},"spec":{"domain":{"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test-disk-00"},{"disk":{"bus":"virtio"},"name":"test-disk-01"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}},"cpu":{"cores":1}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test-disk-00","persistentVolumeClaim":{"claimName":"mypvc1"}},{"name":"test-disk-01","persistentVolumeClaim":{"claimName":"mypvc2"}}]}}},"apiVersion":"kubevirt.io/v1alpha3"}'
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept:
       - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
-      Content-Type:
-      - application/json
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJldmlydCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJrdWJldmlydC1wcml2aWxlZ2VkLXRva2VuLThwbDg5Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Imt1YmV2aXJ0LXByaXZpbGVnZWQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiJkY2I3NjMwMC0zZTZhLTExZTktODk4Ny1iY2UyMjM1M2E1MDUiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6a3ViZXZpcnQ6a3ViZXZpcnQtcHJpdmlsZWdlZCJ9.hFy9NZ1JD-YSXFnBiPDYBeCe1N8_GF3wvTyDCZ_JmMU-aFN-vo-KOkoRJ46Z9oRiexMLV4wsEGEQVdxK4Fi1DObmNni9s2pEwaC-Ae4hylY3rredliwqsHxHMsfOlTc2M0aJmnpLMCB-8H0Bk4RjT_CqIGZzFgWpVgMItd8WtrLADX5jQ9muGhJA8uMvlkPQ97RQ05ndjrJ7glRb497JqdaOrvu6CQoxei309JIVUcMzwzKXtvLwMMJGN5eJppULIywOrIHZHA-X_RPzfQcNIfpApNis4mEJNJZu717-HvmL0pHK8Xld93pvBXW-SeknwzpTRGRfE4_jWDQaQ4yBNg
-      Content-Length:
-      - '664'
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
   response:
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
-      Content-Length:
-      - '875'
+      - Sun, 24 Mar 2019 20:41:45 GMT
+      Transfer-Encoding:
+      - chunked
     body:
       encoding: UTF-8
-      string: '{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-21T10:44:20Z","generation":1,"labels":{"kubevirt.io/vm":"test"},"name":"test","namespace":"default","resourceVersion":"734888","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test","uid":"489c6fba-4bc6-11e9-9c46-bce22353a505"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test-disk-00"},{"disk":{"bus":"virtio"},"name":"test-disk-01"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test-disk-00","persistentVolumeClaim":{"claimName":"mypvc1"}},{"name":"test-disk-01","persistentVolumeClaim":{"claimName":"mypvc2"}}]}}}}
+      string: '{"apiVersion":"kubevirt.io/v1alpha3","items":[{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-24T20:41:19Z","generation":1,"labels":{"kubevirt.io/vm":"test"},"name":"test","namespace":"default","resourceVersion":"3260848","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test","uid":"2dca9be4-4e75-11e9-8e8c-5254007d353d"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test-disk-00"},{"disk":{"bus":"virtio"},"name":"test-disk-01"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test-disk-00","persistentVolumeClaim":{"claimName":"mypvc1"}},{"name":"test-disk-01","persistentVolumeClaim":{"claimName":"mypvc2"}}]}}}},{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-24T20:41:19Z","generation":1,"labels":{"kubevirt.io/vm":"test2"},"name":"test2","namespace":"default","resourceVersion":"3260847","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test2","uid":"2dbf05ef-4e75-11e9-8e8c-5254007d353d"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test2"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test2-disk-00"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test2-disk-00","persistentVolumeClaim":{"claimName":"mypvc3"}}]}}}},{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-21T08:53:21Z","generation":3,"labels":{"special":"vm-multus-pvc"},"name":"vm-multus-pvc","namespace":"default","resourceVersion":"2744764","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/vm-multus-pvc","uid":"c7c8e72d-4bb6-11e9-8e8c-5254007d353d"},"spec":{"running":true,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"vm-multus-pvc"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"vm-multus-pvc-volume"}],"interfaces":[{"bootOrder":1,"bridge":{},"macAddress":"de:00:00:11:11:de","name":"ovs-foreman"}]},"machine":{"type":"q35"},"resources":{"requests":{"memory":"512M"}}},"networks":[{"multus":{"networkName":"ovs-foreman"},"name":"ovs-foreman"}],"terminationGracePeriodSeconds":0,"volumes":[{"name":"vm-multus-pvc-volume","persistentVolumeClaim":{"claimName":"example-local-claim"}}]}}},"status":{"created":true,"ready":true}}],"kind":"VirtualMachineList","metadata":{"continue":"","resourceVersion":"3260891","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines"}}
 
 '
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:41:45 GMT
 - request:
     method: get
-    uri: https://10.8.254.82:8443/apis/kubevirt.io
+    uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines
     body:
       encoding: US-ASCII
       string: ''
@@ -144,7 +45,9 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
   response:
     status:
       code: 200
@@ -153,16 +56,16 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
+      - Sun, 24 Mar 2019 20:43:03 GMT
       Content-Length:
-      - '274'
+      - '1235'
     body:
       encoding: UTF-8
-      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"},{"groupVersion":"kubevirt.io/v1alpha1","version":"v1alpha1"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
+      string: '{"apiVersion":"kubevirt.io/v1alpha3","items":[{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-21T08:53:21Z","generation":3,"labels":{"special":"vm-multus-pvc"},"name":"vm-multus-pvc","namespace":"default","resourceVersion":"2744764","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/vm-multus-pvc","uid":"c7c8e72d-4bb6-11e9-8e8c-5254007d353d"},"spec":{"running":true,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"vm-multus-pvc"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"vm-multus-pvc-volume"}],"interfaces":[{"bootOrder":1,"bridge":{},"macAddress":"de:00:00:11:11:de","name":"ovs-foreman"}]},"machine":{"type":"q35"},"resources":{"requests":{"memory":"512M"}}},"networks":[{"multus":{"networkName":"ovs-foreman"},"name":"ovs-foreman"}],"terminationGracePeriodSeconds":0,"volumes":[{"name":"vm-multus-pvc-volume","persistentVolumeClaim":{"claimName":"example-local-claim"}}]}}},"status":{"created":true,"ready":true}}],"kind":"VirtualMachineList","metadata":{"continue":"","resourceVersion":"3261028","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines"}}
 
 '
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:43:03 GMT
 - request:
     method: get
     uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test
@@ -175,9 +78,9 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJldmlydCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJrdWJldmlydC1wcml2aWxlZ2VkLXRva2VuLThwbDg5Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Imt1YmV2aXJ0LXByaXZpbGVnZWQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiJkY2I3NjMwMC0zZTZhLTExZTktODk4Ny1iY2UyMjM1M2E1MDUiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6a3ViZXZpcnQ6a3ViZXZpcnQtcHJpdmlsZWdlZCJ9.hFy9NZ1JD-YSXFnBiPDYBeCe1N8_GF3wvTyDCZ_JmMU-aFN-vo-KOkoRJ46Z9oRiexMLV4wsEGEQVdxK4Fi1DObmNni9s2pEwaC-Ae4hylY3rredliwqsHxHMsfOlTc2M0aJmnpLMCB-8H0Bk4RjT_CqIGZzFgWpVgMItd8WtrLADX5jQ9muGhJA8uMvlkPQ97RQ05ndjrJ7glRb497JqdaOrvu6CQoxei309JIVUcMzwzKXtvLwMMJGN5eJppULIywOrIHZHA-X_RPzfQcNIfpApNis4mEJNJZu717-HvmL0pHK8Xld93pvBXW-SeknwzpTRGRfE4_jWDQaQ4yBNg
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
   response:
     status:
       code: 200
@@ -186,16 +89,16 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
+      - Mon, 25 Mar 2019 09:36:51 GMT
       Content-Length:
-      - '875'
+      - '1056'
     body:
       encoding: UTF-8
-      string: '{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-21T10:44:20Z","generation":1,"labels":{"kubevirt.io/vm":"test"},"name":"test","namespace":"default","resourceVersion":"734888","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test","uid":"489c6fba-4bc6-11e9-9c46-bce22353a505"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test-disk-00"},{"disk":{"bus":"virtio"},"name":"test-disk-01"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test-disk-00","persistentVolumeClaim":{"claimName":"mypvc1"}},{"name":"test-disk-01","persistentVolumeClaim":{"claimName":"mypvc2"}}]}}}}
+      string: '{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-25T09:36:51Z","generation":1,"labels":{"kubevirt.io/vm":"test"},"name":"test","namespace":"default","resourceVersion":"3291549","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test","uid":"84cf39a1-4ee1-11e9-8e8c-5254007d353d"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"bootOrder":1,"disk":{"bus":"virtio"},"name":"test-disk-01"},{"bootOrder":2,"disk":{"bus":"virtio"},"name":"test-disk-02"},{"bootOrder":3,"disk":{},"name":"test-disk-03"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test-disk-01","persistentVolumeClaim":{"claimName":"mypvc1"}},{"name":"test-disk-02","persistentVolumeClaim":{"claimName":"mypvc2"}},{"hostDisk":{"capacity":"1Gi","path":"/mnt/data/disk.img","type":"DiskOrCreate"},"name":"test-disk-03"}]}}}}
 
 '
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:36:51 GMT
 - request:
     method: get
     uri: https://10.8.254.82:8443/apis/kubevirt.io
@@ -208,7 +111,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
   response:
     status:
       code: 200
@@ -217,19 +120,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
+      - Mon, 25 Mar 2019 09:36:51 GMT
       Content-Length:
-      - '274'
+      - '213'
     body:
       encoding: UTF-8
-      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"},{"groupVersion":"kubevirt.io/v1alpha1","version":"v1alpha1"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
+      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
 
 '
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:36:51 GMT
 - request:
     method: get
-    uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines
+    uri: https://10.8.254.82:8443/apis/kubevirt.io
     body:
       encoding: US-ASCII
       string: ''
@@ -239,9 +142,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJldmlydCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJrdWJldmlydC1wcml2aWxlZ2VkLXRva2VuLThwbDg5Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Imt1YmV2aXJ0LXByaXZpbGVnZWQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiJkY2I3NjMwMC0zZTZhLTExZTktODk4Ny1iY2UyMjM1M2E1MDUiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6a3ViZXZpcnQ6a3ViZXZpcnQtcHJpdmlsZWdlZCJ9.hFy9NZ1JD-YSXFnBiPDYBeCe1N8_GF3wvTyDCZ_JmMU-aFN-vo-KOkoRJ46Z9oRiexMLV4wsEGEQVdxK4Fi1DObmNni9s2pEwaC-Ae4hylY3rredliwqsHxHMsfOlTc2M0aJmnpLMCB-8H0Bk4RjT_CqIGZzFgWpVgMItd8WtrLADX5jQ9muGhJA8uMvlkPQ97RQ05ndjrJ7glRb497JqdaOrvu6CQoxei309JIVUcMzwzKXtvLwMMJGN5eJppULIywOrIHZHA-X_RPzfQcNIfpApNis4mEJNJZu717-HvmL0pHK8Xld93pvBXW-SeknwzpTRGRfE4_jWDQaQ4yBNg
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
   response:
     status:
       code: 200
@@ -250,14 +151,309 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
+      - Mon, 25 Mar 2019 09:40:38 GMT
       Content-Length:
-      - '1080'
+      - '213'
     body:
       encoding: UTF-8
-      string: '{"apiVersion":"kubevirt.io/v1alpha3","items":[{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-21T10:44:20Z","generation":1,"labels":{"kubevirt.io/vm":"test"},"name":"test","namespace":"default","resourceVersion":"734888","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test","uid":"489c6fba-4bc6-11e9-9c46-bce22353a505"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test-disk-00"},{"disk":{"bus":"virtio"},"name":"test-disk-01"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test-disk-00","persistentVolumeClaim":{"claimName":"mypvc1"}},{"name":"test-disk-01","persistentVolumeClaim":{"claimName":"mypvc2"}}]}}}}],"kind":"VirtualMachineList","metadata":{"continue":"","resourceVersion":"734888","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines"}}
+      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
 
 '
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
+- request:
+    method: get
+    uri: https://10.8.254.82:8443/apis/kubevirt.io
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 09:40:38 GMT
+      Content-Length:
+      - '213'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
+
+'
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
+- request:
+    method: get
+    uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 09:40:38 GMT
+      Content-Length:
+      - '1526'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"kubevirt.io/v1alpha3","resources":[{"name":"virtualmachineinstancemigrations","singularName":"virtualmachineinstancemigration","namespaced":true,"kind":"VirtualMachineInstanceMigration","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vmim","vmims"]},{"name":"virtualmachineinstancepresets","singularName":"virtualmachineinstancepreset","namespaced":true,"kind":"VirtualMachineInstancePreset","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vmipreset","vmipresets"]},{"name":"virtualmachineinstancereplicasets","singularName":"virtualmachineinstancereplicaset","namespaced":true,"kind":"VirtualMachineInstanceReplicaSet","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vmirs","vmirss"]},{"name":"virtualmachineinstancereplicasets/scale","singularName":"","namespaced":true,"group":"autoscaling","version":"v1","kind":"Scale","verbs":["get","patch","update"]},{"name":"virtualmachineinstances","singularName":"virtualmachineinstance","namespaced":true,"kind":"VirtualMachineInstance","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vmi","vmis"]},{"name":"virtualmachines","singularName":"virtualmachine","namespaced":true,"kind":"VirtualMachine","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vm","vms"]}]}
+
+'
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
+- request:
+    method: post
+    uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines
+    body:
+      encoding: UTF-8
+      string: '{"kind":"VirtualMachine","metadata":{"labels":{"kubevirt.io/vm":"test"},"name":"test","namespace":"default"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test"}},"spec":{"domain":{"devices":{"disks":[{"name":"test-disk-01","disk":{"bus":"virtio"},"bootOrder":1},{"name":"test-disk-02","disk":{"bus":"virtio"},"bootOrder":2},{"name":"test-disk-03","disk":{},"bootOrder":3}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}},"cpu":{"cores":1}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test-disk-01","persistentVolumeClaim":{"claimName":"mypvc1"}},{"name":"test-disk-02","persistentVolumeClaim":{"claimName":"mypvc2"}},{"name":"test-disk-03","hostDisk":{"capacity":"1Gi","path":"/mnt/data/disk.img","type":"DiskOrCreate"}}]}}},"apiVersion":"kubevirt.io/v1alpha3"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
+      Content-Length:
+      - '844'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 09:40:38 GMT
+      Content-Length:
+      - '1056'
+    body:
+      encoding: UTF-8
+      string: '{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-25T09:40:38Z","generation":1,"labels":{"kubevirt.io/vm":"test"},"name":"test","namespace":"default","resourceVersion":"3291941","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test","uid":"0c1b4784-4ee2-11e9-8e8c-5254007d353d"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"bootOrder":1,"disk":{"bus":"virtio"},"name":"test-disk-01"},{"bootOrder":2,"disk":{"bus":"virtio"},"name":"test-disk-02"},{"bootOrder":3,"disk":{},"name":"test-disk-03"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test-disk-01","persistentVolumeClaim":{"claimName":"mypvc1"}},{"name":"test-disk-02","persistentVolumeClaim":{"claimName":"mypvc2"}},{"hostDisk":{"capacity":"1Gi","path":"/mnt/data/disk.img","type":"DiskOrCreate"},"name":"test-disk-03"}]}}}}
+
+'
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
+- request:
+    method: get
+    uri: https://10.8.254.82:8443/apis/kubevirt.io
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 09:40:38 GMT
+      Content-Length:
+      - '213'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
+
+'
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
+- request:
+    method: get
+    uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 09:40:38 GMT
+      Content-Length:
+      - '1056'
+    body:
+      encoding: UTF-8
+      string: '{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-25T09:40:38Z","generation":1,"labels":{"kubevirt.io/vm":"test"},"name":"test","namespace":"default","resourceVersion":"3291941","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test","uid":"0c1b4784-4ee2-11e9-8e8c-5254007d353d"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"bootOrder":1,"disk":{"bus":"virtio"},"name":"test-disk-01"},{"bootOrder":2,"disk":{"bus":"virtio"},"name":"test-disk-02"},{"bootOrder":3,"disk":{},"name":"test-disk-03"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test-disk-01","persistentVolumeClaim":{"claimName":"mypvc1"}},{"name":"test-disk-02","persistentVolumeClaim":{"claimName":"mypvc2"}},{"hostDisk":{"capacity":"1Gi","path":"/mnt/data/disk.img","type":"DiskOrCreate"},"name":"test-disk-03"}]}}}}
+
+'
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
+- request:
+    method: get
+    uri: https://10.8.254.82:8443/apis/kubevirt.io
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 09:40:38 GMT
+      Content-Length:
+      - '213'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
+
+'
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
+- request:
+    method: get
+    uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 09:40:38 GMT
+      Content-Length:
+      - '1056'
+    body:
+      encoding: UTF-8
+      string: '{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-25T09:40:38Z","generation":1,"labels":{"kubevirt.io/vm":"test"},"name":"test","namespace":"default","resourceVersion":"3291941","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test","uid":"0c1b4784-4ee2-11e9-8e8c-5254007d353d"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"bootOrder":1,"disk":{"bus":"virtio"},"name":"test-disk-01"},{"bootOrder":2,"disk":{"bus":"virtio"},"name":"test-disk-02"},{"bootOrder":3,"disk":{},"name":"test-disk-03"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test-disk-01","persistentVolumeClaim":{"claimName":"mypvc1"}},{"name":"test-disk-02","persistentVolumeClaim":{"claimName":"mypvc2"}},{"hostDisk":{"capacity":"1Gi","path":"/mnt/data/disk.img","type":"DiskOrCreate"},"name":"test-disk-03"}]}}}}
+
+'
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
+- request:
+    method: get
+    uri: https://10.8.254.82:8443/apis/kubevirt.io
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 09:40:56 GMT
+      Content-Length:
+      - '213'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
+
+'
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:56 GMT
+- request:
+    method: delete
+    uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 09:40:56 GMT
+      Content-Length:
+      - '187'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"test","group":"kubevirt.io","kind":"virtualmachines","uid":"0c1b4784-4ee2-11e9-8e8c-5254007d353d"}}
+
+'
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:56 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/kubevirt/vm/vm_create_single.yml
+++ b/spec/fixtures/kubevirt/vm/vm_create_single.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://10.8.254.82:8443/apis/kubevirt.io
+    uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,9 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
   response:
     status:
       code: 200
@@ -21,16 +23,16 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
+      - Sun, 24 Mar 2019 20:41:19 GMT
       Content-Length:
-      - '274'
+      - '1998'
     body:
       encoding: UTF-8
-      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"},{"groupVersion":"kubevirt.io/v1alpha1","version":"v1alpha1"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
+      string: '{"apiVersion":"kubevirt.io/v1alpha3","items":[{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-24T20:41:19Z","generation":1,"labels":{"kubevirt.io/vm":"test2"},"name":"test2","namespace":"default","resourceVersion":"3260847","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test2","uid":"2dbf05ef-4e75-11e9-8e8c-5254007d353d"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test2"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test2-disk-00"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test2-disk-00","persistentVolumeClaim":{"claimName":"mypvc3"}}]}}}},{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-21T08:53:21Z","generation":3,"labels":{"special":"vm-multus-pvc"},"name":"vm-multus-pvc","namespace":"default","resourceVersion":"2744764","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/vm-multus-pvc","uid":"c7c8e72d-4bb6-11e9-8e8c-5254007d353d"},"spec":{"running":true,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"vm-multus-pvc"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"vm-multus-pvc-volume"}],"interfaces":[{"bootOrder":1,"bridge":{},"macAddress":"de:00:00:11:11:de","name":"ovs-foreman"}]},"machine":{"type":"q35"},"resources":{"requests":{"memory":"512M"}}},"networks":[{"multus":{"networkName":"ovs-foreman"},"name":"ovs-foreman"}],"terminationGracePeriodSeconds":0,"volumes":[{"name":"vm-multus-pvc-volume","persistentVolumeClaim":{"claimName":"example-local-claim"}}]}}},"status":{"created":true,"ready":true}}],"kind":"VirtualMachineList","metadata":{"continue":"","resourceVersion":"3260847","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines"}}
 
 '
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
+    http_version:
+  recorded_at: Sun, 24 Mar 2019 20:41:19 GMT
 - request:
     method: get
     uri: https://10.8.254.82:8443/apis/kubevirt.io
@@ -43,7 +45,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
   response:
     status:
       code: 200
@@ -52,16 +54,47 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
+      - Mon, 25 Mar 2019 09:40:38 GMT
       Content-Length:
-      - '274'
+      - '213'
     body:
       encoding: UTF-8
-      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"},{"groupVersion":"kubevirt.io/v1alpha1","version":"v1alpha1"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
+      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
 
 '
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
+- request:
+    method: get
+    uri: https://10.8.254.82:8443/apis/kubevirt.io
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 09:40:38 GMT
+      Content-Length:
+      - '213'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
+
+'
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
 - request:
     method: get
     uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3
@@ -74,9 +107,9 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJldmlydCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJrdWJldmlydC1wcml2aWxlZ2VkLXRva2VuLThwbDg5Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Imt1YmV2aXJ0LXByaXZpbGVnZWQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiJkY2I3NjMwMC0zZTZhLTExZTktODk4Ny1iY2UyMjM1M2E1MDUiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6a3ViZXZpcnQ6a3ViZXZpcnQtcHJpdmlsZWdlZCJ9.hFy9NZ1JD-YSXFnBiPDYBeCe1N8_GF3wvTyDCZ_JmMU-aFN-vo-KOkoRJ46Z9oRiexMLV4wsEGEQVdxK4Fi1DObmNni9s2pEwaC-Ae4hylY3rredliwqsHxHMsfOlTc2M0aJmnpLMCB-8H0Bk4RjT_CqIGZzFgWpVgMItd8WtrLADX5jQ9muGhJA8uMvlkPQ97RQ05ndjrJ7glRb497JqdaOrvu6CQoxei309JIVUcMzwzKXtvLwMMJGN5eJppULIywOrIHZHA-X_RPzfQcNIfpApNis4mEJNJZu717-HvmL0pHK8Xld93pvBXW-SeknwzpTRGRfE4_jWDQaQ4yBNg
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
   response:
     status:
       code: 200
@@ -85,7 +118,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
+      - Mon, 25 Mar 2019 09:40:38 GMT
       Content-Length:
       - '1526'
     body:
@@ -93,25 +126,25 @@ http_interactions:
       string: '{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"kubevirt.io/v1alpha3","resources":[{"name":"virtualmachineinstancemigrations","singularName":"virtualmachineinstancemigration","namespaced":true,"kind":"VirtualMachineInstanceMigration","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vmim","vmims"]},{"name":"virtualmachineinstancepresets","singularName":"virtualmachineinstancepreset","namespaced":true,"kind":"VirtualMachineInstancePreset","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vmipreset","vmipresets"]},{"name":"virtualmachineinstancereplicasets","singularName":"virtualmachineinstancereplicaset","namespaced":true,"kind":"VirtualMachineInstanceReplicaSet","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vmirs","vmirss"]},{"name":"virtualmachineinstancereplicasets/scale","singularName":"","namespaced":true,"group":"autoscaling","version":"v1","kind":"Scale","verbs":["get","patch","update"]},{"name":"virtualmachineinstances","singularName":"virtualmachineinstance","namespaced":true,"kind":"VirtualMachineInstance","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vmi","vmis"]},{"name":"virtualmachines","singularName":"virtualmachine","namespaced":true,"kind":"VirtualMachine","verbs":["delete","deletecollection","get","list","patch","create","update","watch"],"shortNames":["vm","vms"]}]}
 
 '
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
 - request:
     method: post
     uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines
     body:
       encoding: UTF-8
-      string: '{"kind":"VirtualMachine","metadata":{"labels":{"kubevirt.io/vm":"test2"},"name":"test2","namespace":"default"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test2"}},"spec":{"domain":{"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test2-disk-00"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}},"cpu":{"cores":1}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test2-disk-00","persistentVolumeClaim":{"claimName":"mypvc3"}}]}}},"apiVersion":"kubevirt.io/v1alpha3"}'
+      string: '{"kind":"VirtualMachine","metadata":{"labels":{"kubevirt.io/vm":"test2"},"name":"test2","namespace":"default"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test2"}},"spec":{"domain":{"devices":{"disks":[{"name":"test2-disk-00","disk":{"bus":"virtio"}}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}},"cpu":{"cores":1}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test2-disk-00","persistentVolumeClaim":{"claimName":"mypvc3"}}]}}},"apiVersion":"kubevirt.io/v1alpha3"}'
     headers:
       Accept:
       - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJldmlydCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJrdWJldmlydC1wcml2aWxlZ2VkLXRva2VuLThwbDg5Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Imt1YmV2aXJ0LXByaXZpbGVnZWQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiJkY2I3NjMwMC0zZTZhLTExZTktODk4Ny1iY2UyMjM1M2E1MDUiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6a3ViZXZpcnQ6a3ViZXZpcnQtcHJpdmlsZWdlZCJ9.hFy9NZ1JD-YSXFnBiPDYBeCe1N8_GF3wvTyDCZ_JmMU-aFN-vo-KOkoRJ46Z9oRiexMLV4wsEGEQVdxK4Fi1DObmNni9s2pEwaC-Ae4hylY3rredliwqsHxHMsfOlTc2M0aJmnpLMCB-8H0Bk4RjT_CqIGZzFgWpVgMItd8WtrLADX5jQ9muGhJA8uMvlkPQ97RQ05ndjrJ7glRb497JqdaOrvu6CQoxei309JIVUcMzwzKXtvLwMMJGN5eJppULIywOrIHZHA-X_RPzfQcNIfpApNis4mEJNJZu717-HvmL0pHK8Xld93pvBXW-SeknwzpTRGRfE4_jWDQaQ4yBNg
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
       Content-Length:
       - '550'
   response:
@@ -122,16 +155,16 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
+      - Mon, 25 Mar 2019 09:40:38 GMT
       Content-Length:
-      - '762'
+      - '763'
     body:
       encoding: UTF-8
-      string: '{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-21T10:44:20Z","generation":1,"labels":{"kubevirt.io/vm":"test2"},"name":"test2","namespace":"default","resourceVersion":"734889","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test2","uid":"48a9c1c8-4bc6-11e9-9c46-bce22353a505"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test2"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test2-disk-00"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test2-disk-00","persistentVolumeClaim":{"claimName":"mypvc3"}}]}}}}
+      string: '{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-25T09:40:38Z","generation":1,"labels":{"kubevirt.io/vm":"test2"},"name":"test2","namespace":"default","resourceVersion":"3291939","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test2","uid":"0c0afe5d-4ee2-11e9-8e8c-5254007d353d"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test2"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test2-disk-00"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test2-disk-00","persistentVolumeClaim":{"claimName":"mypvc3"}}]}}}}
 
 '
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
 - request:
     method: get
     uri: https://10.8.254.82:8443/apis/kubevirt.io
@@ -144,7 +177,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
   response:
     status:
       code: 200
@@ -153,16 +186,16 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
+      - Mon, 25 Mar 2019 09:40:38 GMT
       Content-Length:
-      - '274'
+      - '213'
     body:
       encoding: UTF-8
-      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"},{"groupVersion":"kubevirt.io/v1alpha1","version":"v1alpha1"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
+      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
 
 '
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
 - request:
     method: get
     uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test2
@@ -175,9 +208,9 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJldmlydCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJrdWJldmlydC1wcml2aWxlZ2VkLXRva2VuLThwbDg5Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Imt1YmV2aXJ0LXByaXZpbGVnZWQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiJkY2I3NjMwMC0zZTZhLTExZTktODk4Ny1iY2UyMjM1M2E1MDUiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6a3ViZXZpcnQ6a3ViZXZpcnQtcHJpdmlsZWdlZCJ9.hFy9NZ1JD-YSXFnBiPDYBeCe1N8_GF3wvTyDCZ_JmMU-aFN-vo-KOkoRJ46Z9oRiexMLV4wsEGEQVdxK4Fi1DObmNni9s2pEwaC-Ae4hylY3rredliwqsHxHMsfOlTc2M0aJmnpLMCB-8H0Bk4RjT_CqIGZzFgWpVgMItd8WtrLADX5jQ9muGhJA8uMvlkPQ97RQ05ndjrJ7glRb497JqdaOrvu6CQoxei309JIVUcMzwzKXtvLwMMJGN5eJppULIywOrIHZHA-X_RPzfQcNIfpApNis4mEJNJZu717-HvmL0pHK8Xld93pvBXW-SeknwzpTRGRfE4_jWDQaQ4yBNg
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
   response:
     status:
       code: 200
@@ -186,16 +219,16 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
+      - Mon, 25 Mar 2019 09:40:38 GMT
       Content-Length:
-      - '762'
+      - '763'
     body:
       encoding: UTF-8
-      string: '{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-21T10:44:20Z","generation":1,"labels":{"kubevirt.io/vm":"test2"},"name":"test2","namespace":"default","resourceVersion":"734889","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test2","uid":"48a9c1c8-4bc6-11e9-9c46-bce22353a505"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test2"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test2-disk-00"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test2-disk-00","persistentVolumeClaim":{"claimName":"mypvc3"}}]}}}}
+      string: '{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-25T09:40:38Z","generation":1,"labels":{"kubevirt.io/vm":"test2"},"name":"test2","namespace":"default","resourceVersion":"3291939","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test2","uid":"0c0afe5d-4ee2-11e9-8e8c-5254007d353d"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test2"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test2-disk-00"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test2-disk-00","persistentVolumeClaim":{"claimName":"mypvc3"}}]}}}}
 
 '
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
 - request:
     method: get
     uri: https://10.8.254.82:8443/apis/kubevirt.io
@@ -208,7 +241,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
   response:
     status:
       code: 200
@@ -217,19 +250,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
+      - Mon, 25 Mar 2019 09:40:38 GMT
       Content-Length:
-      - '274'
+      - '213'
     body:
       encoding: UTF-8
-      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"},{"groupVersion":"kubevirt.io/v1alpha1","version":"v1alpha1"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
+      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
 
 '
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
 - request:
     method: get
-    uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines
+    uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test2
     body:
       encoding: US-ASCII
       string: ''
@@ -239,9 +272,9 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.5.3p105
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJldmlydCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJrdWJldmlydC1wcml2aWxlZ2VkLXRva2VuLThwbDg5Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Imt1YmV2aXJ0LXByaXZpbGVnZWQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiJkY2I3NjMwMC0zZTZhLTExZTktODk4Ny1iY2UyMjM1M2E1MDUiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6a3ViZXZpcnQ6a3ViZXZpcnQtcHJpdmlsZWdlZCJ9.hFy9NZ1JD-YSXFnBiPDYBeCe1N8_GF3wvTyDCZ_JmMU-aFN-vo-KOkoRJ46Z9oRiexMLV4wsEGEQVdxK4Fi1DObmNni9s2pEwaC-Ae4hylY3rredliwqsHxHMsfOlTc2M0aJmnpLMCB-8H0Bk4RjT_CqIGZzFgWpVgMItd8WtrLADX5jQ9muGhJA8uMvlkPQ97RQ05ndjrJ7glRb497JqdaOrvu6CQoxei309JIVUcMzwzKXtvLwMMJGN5eJppULIywOrIHZHA-X_RPzfQcNIfpApNis4mEJNJZu717-HvmL0pHK8Xld93pvBXW-SeknwzpTRGRfE4_jWDQaQ4yBNg
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
   response:
     status:
       code: 200
@@ -250,14 +283,80 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 21 Mar 2019 10:44:20 GMT
+      - Mon, 25 Mar 2019 09:40:38 GMT
       Content-Length:
-      - '1842'
+      - '763'
     body:
       encoding: UTF-8
-      string: '{"apiVersion":"kubevirt.io/v1alpha3","items":[{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-21T10:44:20Z","generation":1,"labels":{"kubevirt.io/vm":"test"},"name":"test","namespace":"default","resourceVersion":"734888","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test","uid":"489c6fba-4bc6-11e9-9c46-bce22353a505"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test-disk-00"},{"disk":{"bus":"virtio"},"name":"test-disk-01"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test-disk-00","persistentVolumeClaim":{"claimName":"mypvc1"}},{"name":"test-disk-01","persistentVolumeClaim":{"claimName":"mypvc2"}}]}}}},{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-21T10:44:20Z","generation":1,"labels":{"kubevirt.io/vm":"test2"},"name":"test2","namespace":"default","resourceVersion":"734889","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test2","uid":"48a9c1c8-4bc6-11e9-9c46-bce22353a505"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test2"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test2-disk-00"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test2-disk-00","persistentVolumeClaim":{"claimName":"mypvc3"}}]}}}}],"kind":"VirtualMachineList","metadata":{"continue":"","resourceVersion":"734889","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines"}}
+      string: '{"apiVersion":"kubevirt.io/v1alpha3","kind":"VirtualMachine","metadata":{"creationTimestamp":"2019-03-25T09:40:38Z","generation":1,"labels":{"kubevirt.io/vm":"test2"},"name":"test2","namespace":"default","resourceVersion":"3291939","selfLink":"/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test2","uid":"0c0afe5d-4ee2-11e9-8e8c-5254007d353d"},"spec":{"running":false,"template":{"metadata":{"creationTimestamp":null,"labels":{"kubevirt.io/vm":"test2"}},"spec":{"domain":{"cpu":{"cores":1},"devices":{"disks":[{"disk":{"bus":"virtio"},"name":"test2-disk-00"}]},"machine":{"type":""},"resources":{"requests":{"memory":"64M"}}},"terminationGracePeriodSeconds":0,"volumes":[{"name":"test2-disk-00","persistentVolumeClaim":{"claimName":"mypvc3"}}]}}}}
 
 '
-    http_version: 
-  recorded_at: Thu, 21 Mar 2019 10:44:20 GMT
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
+- request:
+    method: get
+    uri: https://10.8.254.82:8443/apis/kubevirt.io
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 09:40:38 GMT
+      Content-Length:
+      - '213'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"APIGroup","apiVersion":"v1","name":"kubevirt.io","versions":[{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}],"preferredVersion":{"groupVersion":"kubevirt.io/v1alpha3","version":"v1alpha3"}}
+
+'
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
+- request:
+    method: delete
+    uri: https://10.8.254.82:8443/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/test2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6ImZvcmVtYW4tYWNjb3VudC10b2tlbi1yY3ByMiIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJmb3JlbWFuLWFjY291bnQiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiI1OGY3NTc4NC0yMjUyLTExZTktYjU1NS01MjU0MDA3ZDM1M2QiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6ZGVmYXVsdDpmb3JlbWFuLWFjY291bnQifQ.UDzZu0_mLkJZvgeGE-lgKJOXtwWGt6WoNuEpm8k7VK61_bQFavEsETRUrGar68cebUPdUTWFoFlVStcQXoQoS0PUvqNPmznBcHDUW5Jw7pKaLHUhsqQkOoNzDD4eGcl1KDoagL1E-CkTglcYiMYHM9yykxnK58jyP3HF1rsDLG-c8N-T3bK_tLQ__eqKwPJ7R3RHuCg3M5FX1mH86wuaEsOPW3KW7tlGQpP5hj33-97KMp4GgH3pZMTLgo1JDwGT2GXPW12V7juE18KEvvot6q5S0Akl85Vp_5NCxNANRG9YCsSnUiB1opHBqfTxIO1ykSYHfg2IkuovQh68HDNV5A
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 25 Mar 2019 09:40:38 GMT
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"test2","group":"kubevirt.io","kind":"virtualmachines","uid":"0c0afe5d-4ee2-11e9-8e8c-5254007d353d"}}
+
+'
+    http_version:
+  recorded_at: Mon, 25 Mar 2019 09:40:38 GMT
 recorded_with: VCR 4.0.0

--- a/spec/pvcs_v1alpha2_spec.rb
+++ b/spec/pvcs_v1alpha2_spec.rb
@@ -44,6 +44,13 @@ require 'spec_helper'
           assert_equal(pvc.volume_name, 'my-local-storage')
           assert_equal(pvc.requests[:storage], '2Gi')
           assert_equal(pvc.limits[:storage], '3Gi')
+
+          # test all volumes based on PVCs
+          volumes = @service.volumes.all
+          volume = volumes.select { |v| v.name == name }.first
+          refute_nil(volume)
+          assert_equal(volume.name, 'my-local-storage-pvc')
+          assert_equal(volume.type, 'persistentVolumeClaim')
        ensure
          @service.pvcs.delete(name) if pvc
        end


### PR DESCRIPTION
The 'volumes' collection will allow to list all volumes in the system
that are backed by a PVC or to list all of vm volumes, if given a vm
name while trying to list the volumes.

The Volume class will be used also as a parameter for passing volume for
a virtual machine create request, so additional information could be
specified such as 'bus' and 'boot_order' to determine how the volume
should be configured for the vm.

With this PR also fixed the delete_vm service so cleanup after tests
will work as expected when recording VCR for specs.