### PR TITLE
Wrap version detection with ClientError

### DIFF
--- a/lib/fog/kubevirt/compute/compute.rb
+++ b/lib/fog/kubevirt/compute/compute.rb
@@ -430,7 +430,11 @@ module Fog
             ssl_client_key: ssl_options[:client_key],
           }
 
-          response = ::JSON.parse(RestClient::Resource.new(url, options).get)
+          begin
+            response = ::JSON.parse(RestClient::Resource.new(url, options).get)
+          rescue => e
+            raise ::Fog::Kubevirt::Errors::ClientError, e
+          end
 
           # version detected based on
           # https://github.com/kubernetes-incubator/apiserver-builder/blob/master/docs/concepts/aggregation.md#viewing-discovery-information


### PR DESCRIPTION
The fog-kubevirt should produce the same error for various failures to allow a proper exception handling by the clients.