### PR TITLE
Validate namespace exists

### DIFF
--- a/lib/fog/kubevirt/compute/compute.rb
+++ b/lib/fog/kubevirt/compute/compute.rb
@@ -211,6 +211,13 @@ module Fog
         end
 
         def valid?
+          begin
+            kube_client.get_namespace(namespace)
+          rescue => err
+            @log.warn("The namespace [#{namespace}] does not exist on the kubernetes cluster: #{err.message}")
+            raise "The namespace '#{namespace}' does not exist on the kubernetes cluster"
+          end
+
           kube_client.api_valid?
         end
 


### PR DESCRIPTION
kubevirt_namespace is a require parameter for creating the kubevirt compute service.
There is a need to verify the namespace exists on the cluster, therefore a check for it is being added to the validation method.