### PR TITLE
Verify server is accessible before other validations

### DIFF
--- a/lib/fog/kubevirt/compute/compute.rb
+++ b/lib/fog/kubevirt/compute/compute.rb
@@ -218,14 +218,14 @@ module Fog
         end
 
         def valid?
+          kube_client.api_valid?
+
           begin
             kube_client.get_namespace(namespace)
           rescue => err
             @log.warn("The namespace [#{namespace}] does not exist on the kubernetes cluster: #{err.message}")
             raise "The namespace '#{namespace}' does not exist on the kubernetes cluster"
           end
-
-          kube_client.api_valid?
         end
 
         class WatchWrapper


### PR DESCRIPTION
In order to reflect the exact failure reason, the server should be
tested for connectivity before examining its capabilities.