### PR TITLE
Use mac address reported by kubevirt

### DIFF
--- a/lib/fog/kubevirt/compute/models/vm_base.rb
+++ b/lib/fog/kubevirt/compute/models/vm_base.rb
@@ -43,7 +43,7 @@ module Fog
             :disks            => disks,
             :volumes          => parse_volumes(spec[:volumes], disks),
             :status           => object[:spec][:running].to_s == "true" ? "running" : "stopped",
-            :interfaces       => parse_interfaces(domain[:devices][:interfaces]),
+            :interfaces       => parse_interfaces(domain[:devices][:interfaces], object[:status].nil? ? [] : object[:status][:interfaces]),
             :networks         => parse_networks(spec[:networks]),
             :machine_type     => domain.dig(:machine, :type)
           }

--- a/lib/fog/kubevirt/compute/models/vm_parser.rb
+++ b/lib/fog/kubevirt/compute/models/vm_parser.rb
@@ -12,13 +12,15 @@ module Fog
         #
         # @param object [Hash] A hash with raw interfaces data.
         #
-        def parse_interfaces(object)
+        def parse_interfaces(object, object_status)
           return {} if object.nil?
           nics = []
           object.each do |iface|
             nic = VmNic.new
             nic.name = iface[:name]
-            nic.mac_address = iface[:macAddress]
+            status_iface = object_status.find { |hash| hash[:name] == iface[:name] }
+            # get mac address from status and use device definition if not available
+            nic.mac_address = !status_iface.nil? && status_iface.key?(:mac) ? status_iface[:mac] : iface[:macAddress]
             nic.type = 'bridge' if iface.keys.include?(:bridge)
             nic.type = 'slirp' if iface.keys.include?(:slirp)
             nics << nic

--- a/lib/fog/kubevirt/compute/models/vminstance.rb
+++ b/lib/fog/kubevirt/compute/models/vminstance.rb
@@ -40,7 +40,7 @@ module Fog
             :memory           => domain[:resources][:requests][:memory],
             :disks            => disks,
             :volumes          => parse_volumes(spec[:volumes], disks),
-            :interfaces       => parse_interfaces(domain[:devices][:interfaces]),
+            :interfaces       => parse_interfaces(domain[:devices][:interfaces], status[:interfaces]),
             :networks         => parse_networks(spec[:networks]),
             :ip_address       => status.dig(:interfaces, 0, :ipAddress),
             :node_name        => status[:nodeName],

--- a/spec/vm_parse.rb
+++ b/spec/vm_parse.rb
@@ -1,0 +1,17 @@
+describe Fog::Kubevirt::Compute do
+  it 'parses vm' do
+    mock = Fog::Kubevirt::Compute::Mock.new
+    vm = mock.get_vm('test')
+
+    assert_nil(vm[:interfaces][0].mac_address)
+    assert_nil(vm[:interfaces][1].mac_address)
+  end
+
+  it 'parses vmi' do
+    mock = Fog::Kubevirt::Compute::Mock.new
+    vm = mock.get_vminstance('test')
+
+    assert_equal(vm[:interfaces][0].mac_address, '0e:fc:6c:c3:20:ec')
+    assert_equal(vm[:interfaces][1].mac_address, '4a:90:1c:2e:fe:d7')
+  end
+end


### PR DESCRIPTION
In status section kubevirt reports mac addresses for specific interfaces.
This PR collects those addresses and store them in vminc class.