### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.2.1 / 2019-04-12
+
+* Use mac address reported by kubevirt
+* Do not pass an empty selector
+* Populate PVC for VM volume
+
 ### 1.2.0 / 2019-04-08
 
 * Replace state with phase of Server model

--- a/lib/fog/kubevirt/version.rb
+++ b/lib/fog/kubevirt/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Kubevirt
-    VERSION = '1.2.0'
+    VERSION = '1.2.1'
   end
 end


### PR DESCRIPTION
* Use mac address reported by KubeVirt
* Do not pass an empty selector
* Populate PVC for VM volume