### PR TITLE
Handle scheduled vmis

### DIFF
--- a/lib/fog/kubevirt/compute/models/vm_parser.rb
+++ b/lib/fog/kubevirt/compute/models/vm_parser.rb
@@ -18,7 +18,7 @@ module Fog
           object.each do |iface|
             nic = VmNic.new
             nic.name = iface[:name]
-            status_iface = object_status.find { |hash| hash[:name] == iface[:name] }
+            status_iface = object_status.find { |hash| hash[:name] == iface[:name] } unless object_status.nil?
             # get mac address from status and use device definition if not available
             nic.mac_address = !status_iface.nil? && status_iface.key?(:mac) ? status_iface[:mac] : iface[:macAddress]
             nic.type = 'bridge' if iface.keys.include?(:bridge)

--- a/lib/fog/kubevirt/compute/requests/get_server.rb
+++ b/lib/fog/kubevirt/compute/requests/get_server.rb
@@ -57,7 +57,7 @@ module Fog
         end
 
         def get_server(name)
-          if name == "robin-rykert.example.com"
+          if name == "robin-rykert.example.com" || name == 'no_interfaces'
             disk1 = disk(name: "robin-rykert-example-com-disk-00", boot_order: nil,type: "disk", bus: "virtio", readonly: nil)
             disk2 = disk(name: "robin-rykert-example-com-disk-01", boot_order: nil,type: "disk", bus: "virtio", readonly: nil)
 
@@ -70,6 +70,8 @@ module Fog
             vm_network.name="ovs-foreman"
             vm_network.type="multus"
 
+            interfaces = name != 'no_interfaces' ? [vm_nic(mac_address: "a2:b4:a2:b6:a2:a8")] : nil
+
             return {
               :namespace=>"default",
               :name=>"robin-rykert.example.com",
@@ -79,7 +81,7 @@ module Fog
               :disks=>[disk1, disk2],
               :volumes=>[volume1, volume2],
               :status=>"stopped",
-              :interfaces=>[vm_nic(mac_address: "a2:b4:a2:b6:a2:a8")],
+              :interfaces=>interfaces,
               :networks=>[vm_network],
               :machine_type=>"",
               :cpu_cores=>1,

--- a/spec/vm_parse.rb
+++ b/spec/vm_parse.rb
@@ -14,4 +14,11 @@ describe Fog::Kubevirt::Compute do
     assert_equal(vm[:interfaces][0].mac_address, '0e:fc:6c:c3:20:ec')
     assert_equal(vm[:interfaces][1].mac_address, '4a:90:1c:2e:fe:d7')
   end
+
+  it 'parses not ready server' do
+    mock = Fog::Kubevirt::Compute::Mock.new
+    server = mock.get_server('no_interfaces')
+
+    assert_nil(server[:interfaces])
+  end
 end


### PR DESCRIPTION
There is time when vmi is not running yet. We need to make sure to
handle this scenario when parsing interfaces.