### PR TITLE
Do not rely on attributes defaults

### DIFF
--- a/lib/fog/kubevirt/compute/models/servers.rb
+++ b/lib/fog/kubevirt/compute/models/servers.rb
@@ -21,6 +21,15 @@ module Fog
           new service.get_server(id)
         end
 
+        def new(attributes = {})
+          server = super
+          server.disks = [] unless server.disks
+          server.volumes = [] unless server.volumes
+          server.interfaces = [] unless server.interfaces
+          server.networks = [] unless server.networks
+          server
+        end
+
         def bootstrap(new_attributes = {})
           server = create(new_attributes)
           server.wait_for { stopped? }

--- a/lib/fog/kubevirt/compute/models/vm_base.rb
+++ b/lib/fog/kubevirt/compute/models/vm_base.rb
@@ -17,11 +17,11 @@ module Fog
           attribute :annotations,      :aliases => 'metadata_annotations'
           attribute :cpu_cores,        :aliases => 'spec_cpu_cores'
           attribute :memory,           :aliases => 'spec_memory'
-          attribute :disks,            :aliases => 'spec_disks',               :default => []
-          attribute :volumes,          :aliases => 'spec_volumes',             :default => []
+          attribute :disks,            :aliases => 'spec_disks'
+          attribute :volumes,          :aliases => 'spec_volumes'
           attribute :status,           :aliases => 'spec_running'
-          attribute :interfaces,       :aliases => 'spec_interfaces',          :default => []
-          attribute :networks,         :aliases => 'spec_networks',            :default => []
+          attribute :interfaces,       :aliases => 'spec_interfaces'
+          attribute :networks,         :aliases => 'spec_networks'
           attribute :machine_type,     :aliases => 'spec_machine_type'
         end
 

--- a/lib/fog/kubevirt/compute/models/vm_parser.rb
+++ b/lib/fog/kubevirt/compute/models/vm_parser.rb
@@ -13,7 +13,7 @@ module Fog
         # @param object [Hash] A hash with raw interfaces data.
         #
         def parse_interfaces(object, object_status, networks)
-          return {} if object.nil?
+          return [] if object.nil?
           nics = []
           object.each do |iface|
             nic = VmNic.new
@@ -42,7 +42,7 @@ module Fog
         # @param object [Hash] A hash with raw networks data.
         #
         def parse_networks(object)
-          return {} if object.nil?
+          return [] if object.nil?
           networks = []
           object.each do |net|
             network = VmData::VmNetwork.new
@@ -65,7 +65,7 @@ module Fog
         # @param object [Hash] A hash with raw disks data.
         #
         def parse_disks(object)
-          return {} if object.nil?
+          return [] if object.nil?
           disks = []
           object.each do |d|
             disk = VmData::VmDisk.new
@@ -100,7 +100,7 @@ module Fog
         # @param disks [Array] the disks of the vm associated to the volumes
         #
         def parse_volumes(object, disks)
-          return {} if object.nil?
+          return [] if object.nil?
           volumes = []
           object.each do |v|
             volume = Volume.new

--- a/lib/fog/kubevirt/compute/models/vms.rb
+++ b/lib/fog/kubevirt/compute/models/vms.rb
@@ -23,6 +23,15 @@ module Fog
           load vms
         end
 
+        def new(attributes = {})
+          vm = super
+          vm.disks = [] unless vm.disks
+          vm.volumes = [] unless vm.volumes
+          vm.interfaces = [] unless vm.interfaces
+          vm.networks = [] unless vm.networks
+          vm
+        end
+
         def get(name)
           new service.get_vm(name)
         end


### PR DESCRIPTION
* Using attributes defaults creates a shared object for all of the model
instances. This is undesired behavior, but it is by design.

This PR will initialize the collections to their defaults, and also will
update the parsing methods to return the expected values when being
called (and empty array instead of an empty hash).