### PR TITLE
tests: Allow to configure namespace

### DIFF
--- a/spec/integration/mac_vmi_spec.rb
+++ b/spec/integration/mac_vmi_spec.rb
@@ -55,7 +55,7 @@ describe Fog::Kubevirt::Compute do
     vmis = @client.vminstances.all()
     @watch = @client.watch_vminstances(:resource_version => vmis.resource_version)
 
-    @client.vminstances.destroy(vm_name, 'default')
+    @client.vminstances.destroy(vm_name, @client.namespace)
 
     thread = Thread.new do
       @watch.each do |notice|

--- a/spec/integration/pvcs_spec.rb
+++ b/spec/integration/pvcs_spec.rb
@@ -3,13 +3,14 @@ require_relative './shared_context'
 describe Fog::Kubevirt::Compute do
   before :all do
     conn = KubevirtConnection.new()
+    @namespace = conn.client.namespace
     @client = conn.client.pvcs
   end
 
   it 'CRD pvc' do
     pvc = {
       :name => 'test-pvc',
-      :namespace => 'default',
+      :namespace => @namespace,
       :storage_class => '',
       :access_modes => ['ReadWriteOnce'],
       :requests => { storage: "1Gi" }
@@ -42,7 +43,7 @@ describe Fog::Kubevirt::Compute do
   it 'fails with wrong size format' do
     pvc = {
       :name => 'test-pvc',
-      :namespace => 'default',
+      :namespace => @namespace,
       :storage_class => '',
       :access_modes => ['ReadWriteOnce'],
       :requests => { storage: "X" }

--- a/spec/integration/shared_context.rb
+++ b/spec/integration/shared_context.rb
@@ -8,15 +8,22 @@ class KubevirtConnection
     @host = ENV.key?('KUBE_HOST') ? ENV['KUBE_HOST'] : options[:host]
     @port = ENV.key?('KUBE_PORT') ? ENV['KUBE_PORT'] : options[:port]
     @token = ENV.key?('KUBE_TOKEN') ? ENV['KUBE_TOKEN'] : options[:token]
+    @namespace = ENV.key?('KUBE_NAMESPACE') ? ENV['KUBE_NAMESPACE'] : options[:namespace]
   end
 
   def client
     if !ENV.key?('KUBECONFIG') 
-      return Fog::Kubevirt::Compute.new(:kubevirt_hostname => @host,
-        :kubevirt_port     => @port,
-        :kubevirt_token    => @token)
+      return Fog::Kubevirt::Compute.new(
+        :kubevirt_hostname  => @host,
+        :kubevirt_port      => @port,
+        :kubevirt_token     => @token,
+        :kubevirt_namespace => @namespace
+      )
     else
-      return Fog::Kubevirt::Compute.new(:kubevirt_token => nil)
+      return Fog::Kubevirt::Compute.new(
+        :kubevirt_token     => nil,
+        :kubevirt_namespace => @namespace
+      )
     end
   end
 end


### PR DESCRIPTION
This PR provides ability to customize namespace before running integration tests. In this way we can make sure that not only `default` namespace works well.