### PR TITLE
Fix get_templates API group

### DIFF
--- a/lib/fog/kubevirt/compute/compute.rb
+++ b/lib/fog/kubevirt/compute/compute.rb
@@ -148,6 +148,11 @@ module Fog
         #
         STORAGE_GROUP = 'storage.k8s.io'.freeze
 
+        #
+        # The API group of the Openshift Templates extension:
+        #
+        TEMPLATE_GROUP = 'template.openshift.io'.freeze
+
         def initialize(options={})
           require 'kubeclient'
 
@@ -285,7 +290,7 @@ module Fog
             populate_notice_attributes(template, notice)
             template
           end
-          watch = openshift_client.watch_templates(opts)
+          watch = openshift_template_client.watch_templates(opts)
 
           WatchWrapper.new(watch, mapper)
         end
@@ -431,8 +436,8 @@ module Fog
           version
         end
 
-        def openshift_client
-          create_client('/oapi')
+        def openshift_template_client
+          create_client('/apis/' + TEMPLATE_GROUP)
         end
 
         def kube_client

--- a/lib/fog/kubevirt/compute/requests/get_template.rb
+++ b/lib/fog/kubevirt/compute/requests/get_template.rb
@@ -3,7 +3,7 @@ module Fog
     class Compute
       class Real
         def get_template(name)
-          Template.parse object_to_hash( openshift_client.get_template(name, @namespace) )
+          Template.parse object_to_hash( openshift_template_client.get_template(name, @namespace) )
         end
       end
 

--- a/lib/fog/kubevirt/compute/requests/list_templates.rb
+++ b/lib/fog/kubevirt/compute/requests/list_templates.rb
@@ -5,7 +5,7 @@ module Fog
     class Compute
       class Real
         def list_templates(_filters = {})
-          temps = openshift_client.get_templates(namespace: @namespace)
+          temps = openshift_template_client.get_templates(namespace: @namespace)
           entities = temps.map do |kubevirt_obj|
             Template.parse object_to_hash(kubevirt_obj)
           end


### PR DESCRIPTION
The OpenShift /oapi endpoint has been discontinued and the API group for templates is `template.openshift.io/v1`

This fixes the 404 exception when listing templates on modern openshift 4 clusters

Tested with:
OpenShift version: 4.9.12
Kubernetes version: v1.22.3+e790d7f
OpenShift Virtualization: 4.9.2