### PR TITLE
Fix undefined method exception handling 404 error

### DIFF
--- a/lib/fog/kubevirt/compute/models/services.rb
+++ b/lib/fog/kubevirt/compute/models/services.rb
@@ -12,12 +12,16 @@ module Fog
         def all(filters = {})
           begin
             srvs = service.list_services(filters)
+
+            @kind = srvs.kind
+            @resource_version = srvs.resource_version
           rescue ::Fog::Kubevirt::Errors::ClientError
             # we assume that we get 404
             srvs = []
+
+            @kind = 'Service'
           end
-          @kind = srvs.kind
-          @resource_version = srvs.resource_version
+
           load srvs
         end
 

--- a/lib/fog/kubevirt/compute/models/templates.rb
+++ b/lib/fog/kubevirt/compute/models/templates.rb
@@ -12,12 +12,16 @@ module Fog
         def all(filters = {})
           begin
             temps = service.list_templates(filters)
+
+            @kind = temps.kind
+            @resource_version = temps.resource_version
           rescue ::Fog::Kubevirt::Errors::ClientError
             # we assume that we get 404
             temps = []
+
+            @kind = 'Template'
           end
-          @kind = temps.kind
-          @resource_version = temps.resource_version
+
           load temps
         end
 

--- a/lib/fog/kubevirt/compute/models/vminstances.rb
+++ b/lib/fog/kubevirt/compute/models/vminstances.rb
@@ -12,12 +12,16 @@ module Fog
         def all(filters = {})
           begin
             vms = service.list_vminstances(filters)
+
+            @kind = vms.kind
+            @resource_version = vms.resource_version
           rescue ::Fog::Kubevirt::Errors::ClientError
             # we assume that we get 404
             vms = []
+
+            @kind = 'VirtualMachineInstance'
           end
-          @kind = vms.kind
-          @resource_version = vms.resource_version
+
           load vms
         end
 

--- a/lib/fog/kubevirt/compute/models/vms.rb
+++ b/lib/fog/kubevirt/compute/models/vms.rb
@@ -14,12 +14,16 @@ module Fog
         def all(filters = {})
           begin
             vms = service.list_vms(filters)
+
+            @kind = vms.kind
+            @resource_version = vms.resource_version
           rescue ::Fog::Kubevirt::Errors::ClientError
             # we assume that we get 404
             vms = []
+
+            @kind = 'VirtualMachine'
           end
-          @kind = vms.kind
-          @resource_version = vms.resource_version
+
           load vms
         end
 


### PR DESCRIPTION
If an API call raises a `Fog::Kubevirt::Errors::ClientError` exception due to a 404 the `def all` methods are catching that exception and setting the result to `[]`.

Later on the method then tries to set the `@kind` and `@resource_version` instance variables to e.g. `vms.kind` and `vms.resource_version` which fails if `vms = []`.

Fixes https://github.com/fog/fog-kubevirt/issues/148