### PR TITLE
Bump kubeclient >= 4.9.3 to avoid Kubeclient::Config vulnerability

### DIFF
--- a/fog-kubevirt.gemspec
+++ b/fog-kubevirt.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 3.5"
 
   spec.add_dependency("fog-core", "~> 2.1")
-  spec.add_dependency("kubeclient", "~> 4.3")
+  spec.add_dependency("kubeclient", ">= 4.9.3", "< 5.0.0")
 end


### PR DESCRIPTION
4.9.3 fixed [CVE-2022-0759 in `Kubeclient::Config`](https://github.com/ManageIQ/kubeclient/issues/554), which I see you do use, at least in `create_client_from_config`.

Current "~> 4.3" range already allows 4.9.x but safer to force it as minimum.