### PR TITLE
Fix kwargs ArgumentError on ruby3

### DIFF
--- a/lib/fog/kubevirt/compute/compute.rb
+++ b/lib/fog/kubevirt/compute/compute.rb
@@ -371,7 +371,7 @@ module Fog
           client = Kubeclient::Client.new(
             url.to_s,
             version,
-            @opts
+            **@opts
           )
 
           wrap_client(client, version, key)


### PR DESCRIPTION
```
[ArgumentError]: wrong number of arguments (given 3, expected 1..2)
/home/grare/adam/.gem/ruby/3.1.0/gems/kubeclient-4.12.0/lib/kubeclient.rb:22:in `initialize'
```

Related:
* https://github.com/ManageIQ/kubeclient/issues/431
* https://github.com/ManageIQ/kubeclient/pull/438

Fixes https://github.com/fog/fog-kubevirt/issues/155